### PR TITLE
feat: GPU for snark & risc & compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ categories = ["cryptography"]
 
 circuit_mersenne_field = { path = "circuit_mersenne_field"}
 
-boojum = { git = "https://github.com/matter-labs/zksync-crypto.git", package="boojum", branch = "main" , features = ["log_tracing"]}
-bellman = { git = "https://github.com/matter-labs/zksync-crypto.git", package="zksync_bellman", branch = "main" }
-rescue_poseidon = { git = "https://github.com/matter-labs/zksync-crypto.git", package="rescue_poseidon", branch = "main" }
-snark_wrapper = { git = "https://github.com/matter-labs/zksync-crypto.git", package="snark_wrapper", branch = "main" }
+boojum = { version = "=0.32.2", features = ["log_tracing"] }
+bellman = { package = "zksync_bellman", version = "=0.32.2"}
+rescue_poseidon = "=0.32.2"
+snark_wrapper = "=0.32.2"
 
 # boojum = { path = "../zksync-crypto/crates/boojum"}
 # bellman = { path = "../zksync-crypto/crates/bellman", package="zksync_bellman"}
@@ -55,4 +55,7 @@ clap = { version = "4.5.21", features = ["derive"] }
 sha3 = "*"
 rand = "0.8"
 
-
+# Used for GPU proving.
+shivini = "=0.154.7"
+proof-compression = "=0.154.7"
+zksync-gpu-prover = "=0.154.7"

--- a/circuit_mersenne_field/src/field.rs
+++ b/circuit_mersenne_field/src/field.rs
@@ -1315,7 +1315,7 @@ fn range_check_32_bits<F: SmallField, CS: ConstraintSystem<F>>(cs: &mut CS, vari
 
     if let Some(table_id) = get_16_bits_range_check_table(&*cs) {
         let limbs =
-            decompose_into_limbs::<F, CS, 2>(cs, F::from_u64_unchecked(1u64 << 16), variable);
+            decompose_into_limbs::<F, CS, 4>(cs, F::from_u64_unchecked(1u64 << 16), variable);
 
         let zero = cs.allocate_constant(F::ZERO);
         match cs.get_lookup_params().lookup_width() {
@@ -1349,7 +1349,7 @@ fn range_check_31_bits<F: SmallField, CS: ConstraintSystem<F>>(cs: &mut CS, vari
         get_15_bits_range_check_table(&*cs),
     ) {
         let limbs =
-            decompose_into_limbs::<F, CS, 2>(cs, F::from_u64_unchecked(1u64 << 16), variable);
+            decompose_into_limbs::<F, CS, 4>(cs, F::from_u64_unchecked(1u64 << 16), variable);
 
         let zero = cs.allocate_constant(F::ZERO);
         match cs.get_lookup_params().lookup_width() {

--- a/circuit_mersenne_field/src/field.rs
+++ b/circuit_mersenne_field/src/field.rs
@@ -1314,6 +1314,7 @@ fn range_check_32_bits<F: SmallField, CS: ConstraintSystem<F>>(cs: &mut CS, vari
     use boojum::gadgets::u8::get_8_by_8_range_check_table;
 
     if let Some(table_id) = get_16_bits_range_check_table(&*cs) {
+        // We are decomposing to 4 limbs. In practice 2 would be enough, but GPU doesn't support reduction gate with 2.
         let limbs =
             decompose_into_limbs::<F, CS, 4>(cs, F::from_u64_unchecked(1u64 << 16), variable);
 
@@ -1348,6 +1349,8 @@ fn range_check_31_bits<F: SmallField, CS: ConstraintSystem<F>>(cs: &mut CS, vari
         get_16_bits_range_check_table(&*cs),
         get_15_bits_range_check_table(&*cs),
     ) {
+        // We are decomposing to 4 limbs. In practice 2 would be enough, but GPU doesn't support reduction gate with 2.
+
         let limbs =
             decompose_into_limbs::<F, CS, 4>(cs, F::from_u64_unchecked(1u64 << 16), variable);
 

--- a/docs/end_to_end.md
+++ b/docs/end_to_end.md
@@ -53,5 +53,22 @@ To use gpu, you must:
 For example, you can snark-wrap the airbender risk program proof:
 
 ```shell
-time CUDA_VISIBLE_DEVICES=0 RUST_BACKTRACE=1 RUST_MIN_STACK=267108864 cargo run --bin wrapper --release  prove-full --input wrapper/testing_data/risc_proof --trusted-setup-file crs/setup_compact.key  --output-dir /tmp/snark_output
+time CUDA_VISIBLE_DEVICES=0 RUST_BACKTRACE=1 RUST_MIN_STACK=267108864 cargo run --bin wrapper --release --features gpu  prove-full --input wrapper/testing_data/risc_proof --trusted-setup-file crs/setup_compact.key  --output-dir /tmp/snark_output
 ```
+
+You can also pre-generate VKs & computations, that will later speed up your proving:
+
+```shell
+CUDA_VISIBLE_DEVICES=0 RUST_BACKTRACE=1 RUST_MIN_STACK=267108864 cargo run --bin wrapper --release  generate-snark-vk  --trusted-setup-file crs/setup_compact.key --output-dir /tmp/precomputations
+```
+
+Precomputations take around 7GB.
+
+And then you use them by setting `precomputation-dir` flag:
+
+```shell
+time CUDA_VISIBLE_DEVICES=0 RUST_BACKTRACE=1 RUST_MIN_STACK=267108864 cargo run --bin wrapper --release --features gpu  prove-full --input wrapper/testing_data/risc_proof --trusted-setup-file crs/setup_compact.key  --precomputation-dir /tmp/preprocessing --output-dir /tmp/snark_output
+```
+
+
+

--- a/docs/end_to_end.md
+++ b/docs/end_to_end.md
@@ -40,3 +40,18 @@ If you need to regenerate the wrapper, due to changes in the last airbender recu
 ```bash
 cargo run --bin wrapper_generator --release
 ```
+
+
+## GPU
+
+To use gpu, you must:
+* compile with gpu feature flag
+* install BELLMAN_CUDA (and set BELLMAN_CUDA_DIR=)
+* download the compact CRS file (4GB) (https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_compact.key)
+
+
+For example, you can snark-wrap the airbender risk program proof:
+
+```shell
+time CUDA_VISIBLE_DEVICES=0 RUST_BACKTRACE=1 RUST_MIN_STACK=267108864 cargo run --bin wrapper --release  prove-full --input wrapper/testing_data/risc_proof --trusted-setup-file crs/setup_compact.key  --output-dir /tmp/snark_output
+```

--- a/wrapper/Cargo.toml
+++ b/wrapper/Cargo.toml
@@ -41,5 +41,5 @@ hex = "0.4.3"
 
 gpu = ["shivini", "proof-compression", "zksync-gpu-prover"]
 
-default = ["gpu"]
-#default = []
+#default = ["gpu"]
+default = []

--- a/wrapper/Cargo.toml
+++ b/wrapper/Cargo.toml
@@ -41,5 +41,5 @@ hex = "0.4.3"
 
 gpu = ["shivini", "proof-compression", "zksync-gpu-prover"]
 
-#default = ["gpu"]
-default = []
+default = ["gpu"]
+#default = []

--- a/wrapper/Cargo.toml
+++ b/wrapper/Cargo.toml
@@ -27,6 +27,18 @@ serde.workspace = true
 clap.workspace = true
 sha3.workspace = true
 
+
+shivini = { workspace = true, optional = true } 
+proof-compression = {workspace = true, optional = true}
+zksync-gpu-prover = {workspace = true, optional = true}
+
 [dev-dependencies]
 rand.workspace = true
 hex = "0.4.3"
+
+
+[features]
+
+gpu = ["shivini", "proof-compression", "zksync-gpu-prover"]
+
+default = ["gpu"]

--- a/wrapper/Cargo.toml
+++ b/wrapper/Cargo.toml
@@ -41,4 +41,5 @@ hex = "0.4.3"
 
 gpu = ["shivini", "proof-compression", "zksync-gpu-prover"]
 
-default = ["gpu"]
+#default = ["gpu"]
+default = []

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -184,10 +184,10 @@ impl<F: SmallField, V: CircuitLeafInclusionVerifier<F>> CircuitBuilder<F>
         let builder =
             NopGate::configure_builder(builder, GatePlacementStrategy::UseGeneralPurposeColumns);
 
-        let builder = ReductionGate::<F, 2>::configure_builder(
+        /*let builder = ReductionGate::<F, 2>::configure_builder(
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
-        );
+        );*/
         let builder = ZeroCheckGate::configure_builder(
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
@@ -205,10 +205,10 @@ impl<F: SmallField, V: CircuitLeafInclusionVerifier<F>> CircuitBuilder<F>
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
         );
-        let builder = U32AddCarryAsChunkGate::configure_builder(
+        /*let builder = U32AddCarryAsChunkGate::configure_builder(
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
-        );
+        );*/
 
         builder
     }

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -4,8 +4,7 @@ use boojum::{
         cs_builder::{CsBuilder, CsBuilderImpl},
         gates::{
             ConstantsAllocatorGate, FmaGateInBaseFieldWithoutConstant, NopGate, PublicInputGate,
-            ReductionGate, SelectionGate, U32AddCarryAsChunkGate, U32TriAddCarryAsChunkGate,
-            UIntXAddGate, ZeroCheckGate,
+            ReductionGate, SelectionGate, U32TriAddCarryAsChunkGate, UIntXAddGate, ZeroCheckGate,
         },
         implementations::prover::ProofConfig,
         traits::{circuit::CircuitBuilder, cs::ConstraintSystem, gate::GatePlacementStrategy},
@@ -184,6 +183,7 @@ impl<F: SmallField, V: CircuitLeafInclusionVerifier<F>> CircuitBuilder<F>
         let builder =
             NopGate::configure_builder(builder, GatePlacementStrategy::UseGeneralPurposeColumns);
 
+        // This gate is not supported by GPU. If we added support for it, then we should also set the limbs2 in range_check_32_bits in field.rs
         /*let builder = ReductionGate::<F, 2>::configure_builder(
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
@@ -205,6 +205,7 @@ impl<F: SmallField, V: CircuitLeafInclusionVerifier<F>> CircuitBuilder<F>
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
         );
+        // This gate is not supported by GPU.
         /*let builder = U32AddCarryAsChunkGate::configure_builder(
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,

--- a/wrapper/src/gpu/compression.rs
+++ b/wrapper/src/gpu/compression.rs
@@ -1,0 +1,151 @@
+use std::alloc::Global;
+
+use boojum::{
+    config::{ProvingCSConfig, SetupCSConfig},
+    cs::{
+        cs_builder::new_builder,
+        cs_builder_reference::CsReferenceImplementationBuilder,
+        implementations::{pow::NoPow, prover::ProofConfig, setup::FinalizationHintsForProver},
+        traits::circuit::CircuitBuilder,
+    },
+    field::goldilocks::GoldilocksField,
+    worker::Worker,
+};
+use shivini::{
+    ProverContext, ProverContextConfig,
+    cs::{GpuSetup, gpu_setup_and_vk_from_base_setup_vk_params_and_hints},
+    gpu_proof_config::GpuProofConfig,
+    gpu_prove_from_external_witness_data,
+};
+
+use crate::{
+    CompressionCircuit, CompressionProof, CompressionTranscript, CompressionTreeHasher,
+    CompressionVK, RiscWrapperProof, RiscWrapperVK,
+};
+
+type GL = GoldilocksField;
+
+pub fn get_compression_setup(
+    worker: &Worker,
+    risc_wrapper_vk: RiscWrapperVK,
+) -> (
+    GpuSetup<CompressionTreeHasher>,
+    CompressionVK,
+    FinalizationHintsForProver,
+) {
+    let start = std::time::Instant::now();
+
+    // Currently the GPU context is initialized here, but it should be done at a higher level.
+    let config = ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+    let _prover_context = ProverContext::create_with_config(config).unwrap();
+
+    let verify_inner_proof: bool = false;
+    let circuit = CompressionCircuit::new(None, risc_wrapper_vk, verify_inner_proof);
+
+    let geometry = CompressionCircuit::geometry();
+    let (max_trace_len, num_vars) = circuit.size_hint();
+
+    let builder_impl = CsReferenceImplementationBuilder::<GL, GL, SetupCSConfig>::new(
+        geometry,
+        max_trace_len.unwrap(),
+    );
+    let builder = new_builder::<_, GL>(builder_impl);
+
+    let builder = CompressionCircuit::configure_builder(builder);
+    let mut cs = builder.build(num_vars.unwrap());
+    circuit.synthesize_into_cs(&mut cs);
+    let (_, finalization_hint) = cs.pad_and_shrink();
+
+    let ProofConfig {
+        fri_lde_factor,
+        merkle_tree_cap_size,
+        ..
+    } = CompressionCircuit::get_proof_config();
+    let cs = cs.into_assembly::<std::alloc::Global>();
+
+    let (setup_base, vk_params, vars_hint, witness_hints) =
+        cs.get_light_setup(worker, fri_lde_factor, merkle_tree_cap_size);
+
+    let (gpu_setup, gpu_vk) =
+        gpu_setup_and_vk_from_base_setup_vk_params_and_hints::<CompressionTreeHasher, _>(
+            setup_base.clone(),
+            vk_params,
+            vars_hint.clone(),
+            witness_hints.clone(),
+            &worker,
+        )
+        .unwrap();
+
+    println!(
+        "compression circuit setup takes {} ms",
+        start.elapsed().as_millis()
+    );
+
+    (gpu_setup, gpu_vk, finalization_hint)
+}
+
+pub fn prove_compression(
+    risc_wrapper_proof: RiscWrapperProof,
+    risc_wrapper_vk: RiscWrapperVK,
+    finalization_hint: &FinalizationHintsForProver,
+    gpu_setup: &GpuSetup<CompressionTreeHasher>,
+    gpu_vk: &CompressionVK,
+    worker: &Worker,
+) -> CompressionProof {
+    let start = std::time::Instant::now();
+
+    // Currently the GPU context is initialized here, but it should be done at a higher level.
+    let config = ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+    let _prover_context = ProverContext::create_with_config(config).unwrap();
+
+    let verify_inner_proof = true;
+    let circuit = CompressionCircuit::new(
+        Some(risc_wrapper_proof),
+        risc_wrapper_vk,
+        verify_inner_proof,
+    );
+
+    let geometry = CompressionCircuit::geometry();
+    let (max_trace_len, num_vars) = circuit.size_hint();
+
+    let builder_impl = CsReferenceImplementationBuilder::<GL, GL, ProvingCSConfig>::new(
+        geometry,
+        max_trace_len.unwrap(),
+    );
+    let builder = new_builder::<_, GL>(builder_impl);
+
+    let builder = CompressionCircuit::configure_builder(builder);
+    let mut cs = builder.build(num_vars.unwrap());
+    circuit.synthesize_into_cs(&mut cs);
+    cs.pad_and_shrink_using_hint(finalization_hint);
+    let cs = cs.into_assembly::<std::alloc::Global>();
+
+    let gpu_proof_config = GpuProofConfig::from_assembly(&cs);
+
+    let external_witness_data = cs.witness.unwrap();
+
+    let proof_config = CompressionCircuit::get_proof_config();
+
+    let proof = gpu_prove_from_external_witness_data::<
+        CompressionTranscript,
+        CompressionTreeHasher,
+        NoPow,
+        Global,
+    >(
+        &gpu_proof_config,
+        &external_witness_data,
+        proof_config,
+        &gpu_setup,
+        &gpu_vk,
+        (),
+        worker,
+    )
+    .unwrap();
+
+    println!(
+        "compression wrapper proving takes {} ms",
+        start.elapsed().as_millis()
+    );
+
+    proof.into()
+}

--- a/wrapper/src/gpu/compression.rs
+++ b/wrapper/src/gpu/compression.rs
@@ -36,6 +36,7 @@ pub fn get_compression_setup(
     let start = std::time::Instant::now();
 
     // Currently the GPU context is initialized here, but it should be done at a higher level.
+    // For compression circuit, we actually have to set the domain size lower.
     let config = ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
     let _prover_context = ProverContext::create_with_config(config).unwrap();
 
@@ -53,6 +54,7 @@ pub fn get_compression_setup(
 
     let builder = CompressionCircuit::configure_builder(builder);
     let mut cs = builder.build(num_vars.unwrap());
+    // compression circuit doesn't have any tables.
     circuit.synthesize_into_cs(&mut cs);
     let (_, finalization_hint) = cs.pad_and_shrink();
 
@@ -95,6 +97,7 @@ pub fn prove_compression(
     let start = std::time::Instant::now();
 
     // Currently the GPU context is initialized here, but it should be done at a higher level.
+    // For compression circuit, we actually have to set the domain size lower.
     let config = ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
     let _prover_context = ProverContext::create_with_config(config).unwrap();
 
@@ -116,6 +119,7 @@ pub fn prove_compression(
 
     let builder = CompressionCircuit::configure_builder(builder);
     let mut cs = builder.build(num_vars.unwrap());
+    // compression circuit doesn't have any tables.
     circuit.synthesize_into_cs(&mut cs);
     cs.pad_and_shrink_using_hint(finalization_hint);
     let cs = cs.into_assembly::<std::alloc::Global>();

--- a/wrapper/src/gpu/mod.rs
+++ b/wrapper/src/gpu/mod.rs
@@ -1,2 +1,3 @@
+pub mod compression;
 pub mod risc_wrapper;
 pub mod snark;

--- a/wrapper/src/gpu/mod.rs
+++ b/wrapper/src/gpu/mod.rs
@@ -1,0 +1,1 @@
+pub mod snark;

--- a/wrapper/src/gpu/mod.rs
+++ b/wrapper/src/gpu/mod.rs
@@ -1,1 +1,2 @@
+pub mod risc_wrapper;
 pub mod snark;

--- a/wrapper/src/gpu/risc_wrapper.rs
+++ b/wrapper/src/gpu/risc_wrapper.rs
@@ -1,0 +1,171 @@
+use std::alloc::Global;
+
+use boojum::{
+    algebraic_props::{round_function::AbsorptionModeOverwrite, sponge::GoldilocksPoseidon2Sponge},
+    config::{ProvingCSConfig, SetupCSConfig},
+    cs::{
+        cs_builder::new_builder,
+        cs_builder_reference::CsReferenceImplementationBuilder,
+        implementations::{
+            pow::NoPow, prover::ProofConfig, setup::FinalizationHintsForProver,
+            transcript::GoldilocksPoisedon2Transcript,
+        },
+        traits::circuit::CircuitBuilder,
+    },
+    field::goldilocks::GoldilocksField,
+    worker::Worker,
+};
+use shivini::{
+    ProverContext, ProverContextConfig,
+    cs::{GpuSetup, gpu_setup_and_vk_from_base_setup_vk_params_and_hints},
+    gpu_proof_config::GpuProofConfig,
+    gpu_prove_from_external_witness_data,
+};
+
+use crate::{
+    BinaryCommitment, RiscWrapper, RiscWrapperProof, RiscWrapperTreeHasher, RiscWrapperVK,
+    RiscWrapperWitness,
+};
+
+type GL = GoldilocksField;
+
+pub fn get_risc_wrapper_setup(
+    worker: &Worker,
+    binary_commitment: BinaryCommitment,
+) -> (
+    GpuSetup<RiscWrapperTreeHasher>,
+    RiscWrapperVK,
+    FinalizationHintsForProver,
+) {
+    let start = std::time::Instant::now();
+
+    let config = ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+    let _prover_context = ProverContext::create_with_config(config).unwrap();
+
+    let verify_inner_proof: bool = false;
+    let circuit = RiscWrapper::new(None, verify_inner_proof, binary_commitment);
+
+    let geometry = RiscWrapper::geometry();
+    let (max_trace_len, num_vars) = circuit.size_hint();
+
+    let builder_impl = CsReferenceImplementationBuilder::<GL, GL, SetupCSConfig>::new(
+        geometry,
+        max_trace_len.unwrap(),
+    );
+    let builder = new_builder::<_, GL>(builder_impl);
+
+    let builder = RiscWrapper::configure_builder(builder);
+    let mut cs = builder.build(num_vars.unwrap());
+    circuit.add_tables(&mut cs);
+    circuit.synthesize_into_cs(&mut cs);
+    let (_, finalization_hint) = cs.pad_and_shrink();
+
+    let ProofConfig {
+        fri_lde_factor,
+        merkle_tree_cap_size,
+        ..
+    } = RiscWrapper::get_proof_config();
+    let cs = cs.into_assembly::<std::alloc::Global>();
+
+    // TODO: for gpu we don't need full setup (light setup is enough)
+
+    let (setup_base, vk_params, vars_hint, witness_hints) =
+        cs.get_light_setup(worker, fri_lde_factor, merkle_tree_cap_size);
+
+    println!("======== STARTING GPU ===========");
+
+    /*let verifier_builder = RiscWrapperCircuitBuilder::dyn_verifier_builder();
+    let verifier = verifier_builder.create_verifier();
+
+    let gpu_proof_config = GpuProofConfig::from_verifier(&verifier);*/
+
+    //let gpu_proof_config = GpuProofConfig::from_assembly(&cs);
+
+    let (gpu_setup, gpu_vk) =
+        gpu_setup_and_vk_from_base_setup_vk_params_and_hints::<RiscWrapperTreeHasher, _>(
+            setup_base.clone(),
+            vk_params,
+            vars_hint.clone(),
+            witness_hints.clone(),
+            &worker,
+        )
+        .unwrap();
+
+    println!(
+        "risc wrapper setup takes {} ms",
+        start.elapsed().as_millis()
+    );
+
+    (gpu_setup, gpu_vk, finalization_hint)
+}
+
+pub fn prove_risc_wrapper(
+    risc_wrapper_witness: RiscWrapperWitness,
+    finalization_hint: &FinalizationHintsForProver,
+    gpu_setup: &GpuSetup<RiscWrapperTreeHasher>,
+    gpu_vk: &RiscWrapperVK,
+    worker: &Worker,
+    binary_commitment: BinaryCommitment,
+) -> RiscWrapperProof {
+    let start = std::time::Instant::now();
+
+    // TODO: this should be somehow done on higher level.
+    let config = ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+    let _prover_context = ProverContext::create_with_config(config).unwrap();
+
+    let verify_inner_proof = true;
+    let circuit = RiscWrapper::new(
+        Some(risc_wrapper_witness),
+        verify_inner_proof,
+        binary_commitment,
+    );
+
+    let geometry = RiscWrapper::geometry();
+    let (max_trace_len, num_vars) = circuit.size_hint();
+
+    let builder_impl = CsReferenceImplementationBuilder::<GL, GL, ProvingCSConfig>::new(
+        geometry,
+        max_trace_len.unwrap(),
+    );
+    let builder = new_builder::<_, GL>(builder_impl);
+
+    let builder = RiscWrapper::configure_builder(builder);
+    let mut cs = builder.build(num_vars.unwrap());
+    circuit.add_tables(&mut cs);
+    circuit.synthesize_into_cs(&mut cs);
+    cs.pad_and_shrink_using_hint(finalization_hint);
+    let cs = cs.into_assembly::<std::alloc::Global>();
+
+    let gpu_proof_config = GpuProofConfig::from_assembly(&cs);
+
+    let external_witness_data = cs.witness.unwrap();
+
+    // WitnessVectorGeneratorPayload is the input - it has circuit wrapper + finaliation hint.
+    // to get this witness data, we do 'synthesize_vector'.
+    // this calls circuit -> sytnehsis - > synthesis inner.
+    // and this does stuff + into assembly.
+    // we return WitnessVectorGeneratorExecutionOutput - circuit + tiwness vec.
+
+    let proof_config = RiscWrapper::get_proof_config();
+
+    type Transcript = GoldilocksPoisedon2Transcript;
+    type Hasher = GoldilocksPoseidon2Sponge<AbsorptionModeOverwrite>;
+
+    let proof = gpu_prove_from_external_witness_data::<Transcript, Hasher, NoPow, Global>(
+        &gpu_proof_config,      // normally taken from 'verifier' - but I don't have any.
+        &external_witness_data, // witness vector (I have it as struct, not bytes)
+        proof_config,           // LDE factors and other stuff.
+        &gpu_setup,
+        &gpu_vk, // vk should be fine
+        (),      // empty shoudl be ok
+        worker,  // ok
+    )
+    .unwrap();
+
+    println!(
+        "risc wrapper proving takes {} ms",
+        start.elapsed().as_millis()
+    );
+
+    proof.into()
+}

--- a/wrapper/src/gpu/snark.rs
+++ b/wrapper/src/gpu/snark.rs
@@ -1,0 +1,197 @@
+use proof_compression::{
+    PlonkSnarkWrapper, ProofSystemDefinition, SnarkWrapperProofSystem,
+    hardcoded_canonical_g2_bases,
+    serialization::{GenericWrapper, PlonkSnarkVerifierCircuitDeviceSetupWrapper},
+};
+use zksync_gpu_prover::{
+    AsyncSetup,
+    bellman::{
+        bn256::Bn256,
+        kate_commitment::{Crs, CrsForMonomialForm},
+        plonk::better_better_cs::{
+            cs::{
+                Assembly, Circuit, PlonkCsWidth4WithNextStepAndCustomGatesParams,
+                SynthesisModeGenerateSetup, SynthesisModeProve,
+            },
+            gates::selector_optimized_with_d_next::SelectorOptimizedWidth4MainGateWithDNext,
+        },
+    },
+};
+
+use crate::{
+    CompressionProof, CompressionVK, L1_VERIFIER_DOMAIN_SIZE_LOG, SnarkWrapperCircuit,
+    SnarkWrapperFunction, SnarkWrapperProof, SnarkWrapperVK,
+};
+
+// The code below is based off the zkos-compressor code.
+// Unfortunately we were not able to use zkos-compressor directly (for example PlonkSnarkWrapper) - as the Compression circuit here is different.
+
+/// Creates setup data (precomputations and verification key) for a given circuit.
+/// crs_file must point at **compact** CRS.
+pub fn gpu_create_snark_setup_data(
+    compression_vk: CompressionVK,
+    crs_file: &str,
+) -> (PlonkSnarkVerifierCircuitDeviceSetupWrapper, SnarkWrapperVK) {
+    let reader = std::fs::File::open(crs_file).unwrap();
+
+    let crs_mons =
+        <PlonkSnarkWrapper as SnarkWrapperProofSystem>::load_compact_raw_crs(reader).unwrap();
+
+    type PlonkAssembly<CSConfig> = Assembly<
+        Bn256,
+        PlonkCsWidth4WithNextStepAndCustomGatesParams,
+        SelectorOptimizedWidth4MainGateWithDNext,
+        CSConfig,
+        zksync_gpu_prover::cuda_bindings::CudaAllocator,
+    >;
+
+    let (precomputation, vk) = {
+        // reimplementing stuff in precompute_plonk_wrapper_circuit (as we have different compression circuit).
+        let fixed_parameters = compression_vk.fixed_parameters.clone();
+        let wrapper_function = SnarkWrapperFunction;
+        let wrapper_circuit = SnarkWrapperCircuit {
+            witness: None,
+            vk: compression_vk.clone(),
+            fixed_parameters,
+            transcript_params: (),
+            wrapper_function,
+        };
+
+        let mut setup_assembly = PlonkAssembly::<SynthesisModeGenerateSetup>::new();
+
+        wrapper_circuit
+            .synthesize(&mut setup_assembly)
+            .expect("must work");
+
+        let hardcoded_finalization_hint = L1_VERIFIER_DOMAIN_SIZE_LOG;
+
+        // It used finalization hint instead (fine - it is 24 for plonk, and 23 for fflonk).
+        setup_assembly.finalize_to_size_log_2(hardcoded_finalization_hint);
+        assert!(setup_assembly.is_satisfied());
+
+        // now gpu part.
+        let mut ctx = PlonkSnarkWrapper::init_context(&crs_mons)
+            .unwrap()
+            .into_inner();
+
+        let worker = zksync_gpu_prover::bellman::worker::Worker::new();
+        let mut precomputation = zksync_gpu_prover::AsyncSetup::<
+            <PlonkSnarkWrapper as ProofSystemDefinition>::Allocator,
+        >::allocate(1 << hardcoded_finalization_hint);
+        precomputation
+            .generate_from_assembly(&worker, &setup_assembly, &mut ctx)
+            .unwrap();
+
+        let hardcoded_g2_bases = hardcoded_canonical_g2_bases();
+        let mut dummy_crs = Crs::<bellman::bn256::Bn256, CrsForMonomialForm>::dummy_crs(1);
+        dummy_crs.g2_monomial_bases = std::sync::Arc::new(hardcoded_g2_bases.to_vec());
+        let vk = zksync_gpu_prover::compute_vk_from_assembly::<
+            _,
+            _,
+            PlonkCsWidth4WithNextStepAndCustomGatesParams,
+            SynthesisModeGenerateSetup,
+        >(&mut ctx, &setup_assembly, &dummy_crs)
+        .unwrap();
+
+        ctx.free_all_slots();
+
+        (
+            PlonkSnarkVerifierCircuitDeviceSetupWrapper::from_inner(precomputation),
+            vk,
+        )
+    };
+    (precomputation, vk)
+}
+
+/// Computes the SnarkProof for a given compression proof.
+pub fn gpu_snark_prove(
+    precomputation: PlonkSnarkVerifierCircuitDeviceSetupWrapper,
+    snark_wrapper_vk: &SnarkWrapperVK,
+    compression_proof: CompressionProof,
+    compression_vk: CompressionVK,
+    crs_file: &str,
+) -> SnarkWrapperProof {
+    let reader = std::fs::File::open(crs_file).unwrap();
+    let finalization_hint: usize = 1 << 24;
+
+    let crs_mons =
+        <PlonkSnarkWrapper as SnarkWrapperProofSystem>::load_compact_raw_crs(reader).unwrap();
+
+    let snark_wrapper_proof = {
+        let input_proof = compression_proof;
+        // Recreate stuff from prove_plonk_snark_wrapper_step
+
+        let input_vk = compression_vk.clone();
+        let mut ctx = PlonkSnarkWrapper::init_context(&crs_mons)
+            .unwrap()
+            .into_inner();
+        let fixed_parameters = input_vk.fixed_parameters.clone();
+
+        let wrapper_function = SnarkWrapperFunction;
+        let circuit = SnarkWrapperCircuit {
+            witness: Some(input_proof),
+            vk: compression_vk.clone(),
+            fixed_parameters,
+            transcript_params: (),
+            wrapper_function,
+        };
+        type PlonkAssembly<CSConfig> = Assembly<
+            Bn256,
+            PlonkCsWidth4WithNextStepAndCustomGatesParams,
+            SelectorOptimizedWidth4MainGateWithDNext,
+            CSConfig,
+            zksync_gpu_prover::cuda_bindings::CudaAllocator,
+        >;
+
+        //let circuit = Self::build_circuit(input_vk.clone(), Some(input_proof));
+
+        let mut proving_assembly = PlonkAssembly::<SynthesisModeProve>::new();
+
+        circuit
+            .synthesize(&mut proving_assembly)
+            .expect("must work");
+
+        //let mut proving_assembly =
+        //<Self as SnarkWrapperProofSystem>::synthesize_for_proving(circuit);
+        let mut precomputation: AsyncSetup = precomputation.into_inner();
+
+        assert!(proving_assembly.is_satisfied());
+        assert!(finalization_hint.is_power_of_two());
+        proving_assembly.finalize_to_size_log_2(finalization_hint.trailing_zeros() as usize);
+        let domain_size = proving_assembly.n() + 1;
+        assert!(domain_size.is_power_of_two());
+        assert!(domain_size == finalization_hint.clone());
+
+        let worker = zksync_gpu_prover::bellman::worker::Worker::new();
+        let start = std::time::Instant::now();
+        let proof = zksync_gpu_prover::create_proof::<
+            _,
+            _,
+            <PlonkSnarkWrapper as ProofSystemDefinition>::Transcript,
+            _,
+        >(
+            &proving_assembly,
+            &mut ctx,
+            &worker,
+            &mut precomputation,
+            None,
+        )
+        .unwrap();
+
+        println!("plonk proving takes {} s", start.elapsed().as_secs());
+        ctx.free_all_slots();
+
+        let result = zksync_gpu_prover::bellman::plonk::better_better_cs::verifier::verify::<
+            _,
+            _,
+            <PlonkSnarkWrapper as ProofSystemDefinition>::Transcript,
+        >(snark_wrapper_vk, &proof, None)
+        .unwrap();
+
+        if !result {
+            panic!("*** WARNING - SNARK FAILED TO VERIFY ****");
+        }
+        proof
+    };
+    snark_wrapper_proof
+}

--- a/wrapper/src/gpu/snark.rs
+++ b/wrapper/src/gpu/snark.rs
@@ -45,62 +45,59 @@ pub fn gpu_create_snark_setup_data(
         zksync_gpu_prover::cuda_bindings::CudaAllocator,
     >;
 
-    let (precomputation, vk) = {
-        // reimplementing stuff in precompute_plonk_wrapper_circuit (as we have different compression circuit).
-        let fixed_parameters = compression_vk.fixed_parameters.clone();
-        let wrapper_function = SnarkWrapperFunction;
-        let wrapper_circuit = SnarkWrapperCircuit {
-            witness: None,
-            vk: compression_vk.clone(),
-            fixed_parameters,
-            transcript_params: (),
-            wrapper_function,
-        };
+    // reimplementing stuff in precompute_plonk_wrapper_circuit (as we have different compression circuit).
+    let fixed_parameters = compression_vk.fixed_parameters.clone();
+    let wrapper_function = SnarkWrapperFunction;
+    let wrapper_circuit = SnarkWrapperCircuit {
+        witness: None,
+        vk: compression_vk.clone(),
+        fixed_parameters,
+        transcript_params: (),
+        wrapper_function,
+    };
 
-        let mut setup_assembly = PlonkAssembly::<SynthesisModeGenerateSetup>::new();
+    let mut setup_assembly = PlonkAssembly::<SynthesisModeGenerateSetup>::new();
 
-        wrapper_circuit
-            .synthesize(&mut setup_assembly)
-            .expect("must work");
+    wrapper_circuit
+        .synthesize(&mut setup_assembly)
+        .expect("must work");
 
-        let hardcoded_finalization_hint = L1_VERIFIER_DOMAIN_SIZE_LOG;
+    let hardcoded_finalization_hint = L1_VERIFIER_DOMAIN_SIZE_LOG;
 
-        // It used finalization hint instead (fine - it is 24 for plonk, and 23 for fflonk).
-        setup_assembly.finalize_to_size_log_2(hardcoded_finalization_hint);
-        assert!(setup_assembly.is_satisfied());
+    // It used finalization hint instead (fine - it is 24 for plonk, and 23 for fflonk).
+    setup_assembly.finalize_to_size_log_2(hardcoded_finalization_hint);
+    assert!(setup_assembly.is_satisfied());
 
-        // now gpu part.
-        let mut ctx = PlonkSnarkWrapper::init_context(&crs_mons)
-            .unwrap()
-            .into_inner();
+    // now gpu part.
+    let mut ctx = PlonkSnarkWrapper::init_context(&crs_mons)
+        .unwrap()
+        .into_inner();
 
-        let worker = zksync_gpu_prover::bellman::worker::Worker::new();
-        let mut precomputation = zksync_gpu_prover::AsyncSetup::<
-            <PlonkSnarkWrapper as ProofSystemDefinition>::Allocator,
-        >::allocate(1 << hardcoded_finalization_hint);
-        precomputation
-            .generate_from_assembly(&worker, &setup_assembly, &mut ctx)
-            .unwrap();
-
-        let hardcoded_g2_bases = hardcoded_canonical_g2_bases();
-        let mut dummy_crs = Crs::<bellman::bn256::Bn256, CrsForMonomialForm>::dummy_crs(1);
-        dummy_crs.g2_monomial_bases = std::sync::Arc::new(hardcoded_g2_bases.to_vec());
-        let vk = zksync_gpu_prover::compute_vk_from_assembly::<
-            _,
-            _,
-            PlonkCsWidth4WithNextStepAndCustomGatesParams,
-            SynthesisModeGenerateSetup,
-        >(&mut ctx, &setup_assembly, &dummy_crs)
+    let worker = zksync_gpu_prover::bellman::worker::Worker::new();
+    let mut precomputation = zksync_gpu_prover::AsyncSetup::<
+        <PlonkSnarkWrapper as ProofSystemDefinition>::Allocator,
+    >::allocate(1 << hardcoded_finalization_hint);
+    precomputation
+        .generate_from_assembly(&worker, &setup_assembly, &mut ctx)
         .unwrap();
 
-        ctx.free_all_slots();
+    let hardcoded_g2_bases = hardcoded_canonical_g2_bases();
+    let mut dummy_crs = Crs::<bellman::bn256::Bn256, CrsForMonomialForm>::dummy_crs(1);
+    dummy_crs.g2_monomial_bases = std::sync::Arc::new(hardcoded_g2_bases.to_vec());
+    let vk = zksync_gpu_prover::compute_vk_from_assembly::<
+        _,
+        _,
+        PlonkCsWidth4WithNextStepAndCustomGatesParams,
+        SynthesisModeGenerateSetup,
+    >(&mut ctx, &setup_assembly, &dummy_crs)
+    .unwrap();
 
-        (
-            PlonkSnarkVerifierCircuitDeviceSetupWrapper::from_inner(precomputation),
-            vk,
-        )
-    };
-    (precomputation, vk)
+    ctx.free_all_slots();
+
+    (
+        PlonkSnarkVerifierCircuitDeviceSetupWrapper::from_inner(precomputation),
+        vk,
+    )
 }
 
 /// Computes the SnarkProof for a given compression proof.
@@ -117,81 +114,74 @@ pub fn gpu_snark_prove(
     let crs_mons =
         <PlonkSnarkWrapper as SnarkWrapperProofSystem>::load_compact_raw_crs(reader).unwrap();
 
-    let snark_wrapper_proof = {
-        let input_proof = compression_proof;
-        // Recreate stuff from prove_plonk_snark_wrapper_step
+    let input_proof = compression_proof;
+    // Recreate stuff from prove_plonk_snark_wrapper_step
 
-        let input_vk = compression_vk.clone();
-        let mut ctx = PlonkSnarkWrapper::init_context(&crs_mons)
-            .unwrap()
-            .into_inner();
-        let fixed_parameters = input_vk.fixed_parameters.clone();
+    let input_vk = compression_vk.clone();
+    let mut ctx = PlonkSnarkWrapper::init_context(&crs_mons)
+        .unwrap()
+        .into_inner();
+    let fixed_parameters = input_vk.fixed_parameters.clone();
 
-        let wrapper_function = SnarkWrapperFunction;
-        let circuit = SnarkWrapperCircuit {
-            witness: Some(input_proof),
-            vk: compression_vk.clone(),
-            fixed_parameters,
-            transcript_params: (),
-            wrapper_function,
-        };
-        type PlonkAssembly<CSConfig> = Assembly<
-            Bn256,
-            PlonkCsWidth4WithNextStepAndCustomGatesParams,
-            SelectorOptimizedWidth4MainGateWithDNext,
-            CSConfig,
-            zksync_gpu_prover::cuda_bindings::CudaAllocator,
-        >;
-
-        //let circuit = Self::build_circuit(input_vk.clone(), Some(input_proof));
-
-        let mut proving_assembly = PlonkAssembly::<SynthesisModeProve>::new();
-
-        circuit
-            .synthesize(&mut proving_assembly)
-            .expect("must work");
-
-        //let mut proving_assembly =
-        //<Self as SnarkWrapperProofSystem>::synthesize_for_proving(circuit);
-        let mut precomputation: AsyncSetup = precomputation.into_inner();
-
-        assert!(proving_assembly.is_satisfied());
-        assert!(finalization_hint.is_power_of_two());
-        proving_assembly.finalize_to_size_log_2(finalization_hint.trailing_zeros() as usize);
-        let domain_size = proving_assembly.n() + 1;
-        assert!(domain_size.is_power_of_two());
-        assert!(domain_size == finalization_hint.clone());
-
-        let worker = zksync_gpu_prover::bellman::worker::Worker::new();
-        let start = std::time::Instant::now();
-        let proof = zksync_gpu_prover::create_proof::<
-            _,
-            _,
-            <PlonkSnarkWrapper as ProofSystemDefinition>::Transcript,
-            _,
-        >(
-            &proving_assembly,
-            &mut ctx,
-            &worker,
-            &mut precomputation,
-            None,
-        )
-        .unwrap();
-
-        println!("plonk proving takes {} s", start.elapsed().as_secs());
-        ctx.free_all_slots();
-
-        let result = zksync_gpu_prover::bellman::plonk::better_better_cs::verifier::verify::<
-            _,
-            _,
-            <PlonkSnarkWrapper as ProofSystemDefinition>::Transcript,
-        >(snark_wrapper_vk, &proof, None)
-        .unwrap();
-
-        if !result {
-            panic!("*** WARNING - SNARK FAILED TO VERIFY ****");
-        }
-        proof
+    let wrapper_function = SnarkWrapperFunction;
+    let circuit = SnarkWrapperCircuit {
+        witness: Some(input_proof),
+        vk: compression_vk.clone(),
+        fixed_parameters,
+        transcript_params: (),
+        wrapper_function,
     };
-    snark_wrapper_proof
+    type PlonkAssembly<CSConfig> = Assembly<
+        Bn256,
+        PlonkCsWidth4WithNextStepAndCustomGatesParams,
+        SelectorOptimizedWidth4MainGateWithDNext,
+        CSConfig,
+        zksync_gpu_prover::cuda_bindings::CudaAllocator,
+    >;
+
+    let mut proving_assembly = PlonkAssembly::<SynthesisModeProve>::new();
+
+    circuit
+        .synthesize(&mut proving_assembly)
+        .expect("must work");
+
+    let mut precomputation: AsyncSetup = precomputation.into_inner();
+
+    assert!(proving_assembly.is_satisfied());
+    assert!(finalization_hint.is_power_of_two());
+    proving_assembly.finalize_to_size_log_2(finalization_hint.trailing_zeros() as usize);
+    let domain_size = proving_assembly.n() + 1;
+    assert!(domain_size.is_power_of_two());
+    assert!(domain_size == finalization_hint.clone());
+
+    let worker = zksync_gpu_prover::bellman::worker::Worker::new();
+    let start = std::time::Instant::now();
+    let proof = zksync_gpu_prover::create_proof::<
+        _,
+        _,
+        <PlonkSnarkWrapper as ProofSystemDefinition>::Transcript,
+        _,
+    >(
+        &proving_assembly,
+        &mut ctx,
+        &worker,
+        &mut precomputation,
+        None,
+    )
+    .unwrap();
+
+    println!("plonk proving takes {} s", start.elapsed().as_secs());
+    ctx.free_all_slots();
+
+    let result = zksync_gpu_prover::bellman::plonk::better_better_cs::verifier::verify::<
+        _,
+        _,
+        <PlonkSnarkWrapper as ProofSystemDefinition>::Transcript,
+    >(snark_wrapper_vk, &proof, None)
+    .unwrap();
+
+    if !result {
+        panic!("*** WARNING - SNARK FAILED TO VERIFY ****");
+    }
+    proof
 }

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -19,6 +19,7 @@ use boojum::algebraic_props::sponge::GoldilocksPoseidon2Sponge;
 use boojum::config::{DevCSConfig, ProvingCSConfig, SetupCSConfig};
 use boojum::cs::cs_builder::new_builder;
 use boojum::cs::cs_builder_reference::CsReferenceImplementationBuilder;
+#[cfg(feature = "gpu")]
 use boojum::cs::implementations::fast_serialization::MemcopySerializable;
 use boojum::cs::implementations::hints::DenseVariablesCopyHint;
 use boojum::cs::implementations::hints::DenseWitnessCopyHint;
@@ -612,6 +613,7 @@ pub fn prove_risc_wrapper_with_snark(
     }
     #[cfg(not(feature = "gpu"))]
     {
+        let _ = precomputation_dir;
         let crs_mons = match trusted_setup_file {
             Some(ref crs_file_str) => get_trusted_setup(crs_file_str),
             None => Crs::<Bn256, CrsForMonomialForm>::crs_42(

--- a/wrapper/src/main.rs
+++ b/wrapper/src/main.rs
@@ -35,6 +35,9 @@ enum Commands {
         /// If missing - will use the 'fake' trusted setup.
         #[arg(long)]
         trusted_setup_file: Option<String>,
+
+        #[arg(long)]
+        precomputation_dir: Option<String>,
     },
     /// Take the riscV final proof, and create a RiscWrapper proof.
     ProveRiscWrapper {
@@ -54,7 +57,7 @@ enum Commands {
         // Binary used to generate the proof.
         // If not specified, take the default binary (fibonacci hasher).
         #[arg(long)]
-        input_binary: String,
+        input_binary: Option<String>,
 
         #[arg(short, long)]
         output_dir: String,
@@ -101,9 +104,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             input_binary,
             output_dir,
             trusted_setup_file,
+            precomputation_dir,
         } => {
             println!("=== Phase 0: Proving");
-            zkos_wrapper::prove(input, input_binary, output_dir, trusted_setup_file, false)?;
+            zkos_wrapper::prove(
+                input,
+                input_binary,
+                output_dir,
+                trusted_setup_file,
+                false,
+                precomputation_dir,
+            )?;
         }
         Commands::ProveRiscWrapper {
             input,
@@ -111,7 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_dir,
         } => {
             println!("=== Phase 0: Proving RiscWrapper");
-            zkos_wrapper::prove(input, input_binary, output_dir, None, true)?;
+            zkos_wrapper::prove(input, input_binary, output_dir, None, true, None)?;
         }
         Commands::GenerateSnarkVk {
             input_binary,
@@ -135,9 +146,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("=== Phase 0: Generating the RiscWrapper verification key");
             generate_and_save_risc_wrapper_vk(input_binary, output_dir, universal_verifier)?;
         }
-        Commands::GetVkHash {
-            vk_path
-        } => {
+        Commands::GetVkHash { vk_path } => {
             verification_hash(vk_path);
         }
     }


### PR DESCRIPTION
## What ❔

* Added GPU support for SNARK and RISC wrappers
* when you compile with --features gpu, it will automatically turn on.

## Why ❔

Makes proving a lot faster - currently < 2 minutes end to end on 3090.

## Comments

This is still a 'simple' solution: GPU context is created and destroyed on each step.
