### PR TITLE
chore: update dependencies to 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ bellman = { package = "zksync_bellman", version = "=0.32.2"}
 rescue_poseidon = "=0.32.2"
 snark_wrapper = "=0.32.2"
 
-final_risc_verifier = {git="https://github.com/matter-labs/zksync-airbender.git", package="final_reduced_risc_v_machine_verifier", features=["proof_utils"], tag = "v0.4.0"}
-reduced_risc_verifier = {git="https://github.com/matter-labs/zksync-airbender.git", package="reduced_risc_v_log_23_machine_verifier", features=["proof_utils"], tag = "v0.4.0"}
-blake_verifier = {git="https://github.com/matter-labs/zksync-airbender.git", package="blake2_with_compression_verifier", features=["proof_utils"], tag = "v0.4.0"}
-execution_utils = {git="https://github.com/matter-labs/zksync-airbender.git", package="execution_utils", tag = "v0.4.0"}
-setups = {git="https://github.com/matter-labs/zksync-airbender.git", package="setups", tag = "v0.4.0"}
-mersenne_field = {git="https://github.com/matter-labs/zksync-airbender.git", package="field", tag = "v0.4.0"}
-zkos_verifier_generator = {git="https://github.com/matter-labs/zksync-airbender.git", package="verifier_generator", tag = "v0.4.0"}
-prover = {git="https://github.com/matter-labs/zksync-airbender.git", package="prover", tag = "v0.4.0"}
+final_risc_verifier = {git="https://github.com/matter-labs/zksync-airbender.git", package="final_reduced_risc_v_machine_verifier", features=["proof_utils"], tag = "v0.4.2"}
+reduced_risc_verifier = {git="https://github.com/matter-labs/zksync-airbender.git", package="reduced_risc_v_log_23_machine_verifier", features=["proof_utils"], tag = "v0.4.2"}
+blake_verifier = {git="https://github.com/matter-labs/zksync-airbender.git", package="blake2_with_compression_verifier", features=["proof_utils"], tag = "v0.4.2"}
+execution_utils = {git="https://github.com/matter-labs/zksync-airbender.git", package="execution_utils", tag = "v0.4.2"}
+setups = {git="https://github.com/matter-labs/zksync-airbender.git", package="setups", tag = "v0.4.2"}
+mersenne_field = {git="https://github.com/matter-labs/zksync-airbender.git", package="field", tag = "v0.4.2"}
+zkos_verifier_generator = {git="https://github.com/matter-labs/zksync-airbender.git", package="verifier_generator", tag = "v0.4.2"}
+prover = {git="https://github.com/matter-labs/zksync-airbender.git", package="prover", tag = "v0.4.2"}
 
 serde_json = { version = "*" }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"]}


### PR DESCRIPTION
## What ❔

* airbender crate had a fix to the bug in risc_simulator, so updating to the newest dependency.