### PR TITLE
feat: Make setup_data cloneable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ sha3 = "*"
 rand = "0.8"
 
 # Used for GPU proving.
-shivini = "=0.154.9"
-proof-compression = "=0.154.9"
-zksync-gpu-prover = "=0.154.9"
+shivini = "=0.154.10"
+proof-compression = "=0.154.10"
+zksync-gpu-prover = "=0.154.10"
 
 [profile.release.package."blake2_with_compression_verifier"]
 opt-level = 1

--- a/wrapper/src/circuits/snark_wrapper.rs
+++ b/wrapper/src/circuits/snark_wrapper.rs
@@ -13,6 +13,7 @@ pub type SnarkWrapperCircuit = WrapperCircuit<
     SnarkWrapperFunction,
 >;
 
+#[derive(Debug, Clone)]
 pub struct SnarkWrapperFunction;
 
 impl ProofWrapperFunction<Bn256> for SnarkWrapperFunction {


### PR DESCRIPTION
Current PLONK SNARK setup data and VK (the same per cycle) can't be used by reference. setup_data is mutably changed & the structure is not cloneable. This leaves us with a set of options:
1. compute the setup data for each proof (slow runtime)
2. compute it once, save it to disk and load it from disk (fast implementation, not optimal; more of a hack)
3. refactor the code to use setup_data as reference (the "right" fix, but very difficult & time-consuming refactoring)
4. make the setup data cloneable, compute it at start and clone it on subsequent calls (pragmatic option)

4 was chosen and this PR contains the changes needed to make it happen (including `gpu` feature flag scoping to allow compilation and not depend on loading from files)

