### PR TITLE
feat: Library interface

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,5 +1,3 @@
-# Used in pull requests
-
 name: Cargo deny check
 on: pull_request
 permissions: read-all
@@ -7,7 +5,7 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         command-arguments: "--allow unmaintained --hide-inclusion-graph"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target/
 Cargo.lock
-wrapper_generator/target
-circuit_mersenne_field/target
+.codex
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ zksync-gpu-prover = { git = "https://github.com/matter-labs/zksync-crypto-gpu.gi
 # proof-compression = { path = "../zksync-crypto-gpu/crates/proof-compression", package = "proof-compression" }
 # zksync-gpu-prover = { path = "../zksync-crypto-gpu/crates/gpu-prover", package = "zksync-gpu-prover" }
 
+tracing = "0.1"
+tracing-subscriber = "0.3"
+
 [profile.release.package."blake2_with_compression_verifier"]
 opt-level = 1
 codegen-units = 256

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ zksync-gpu-prover = { git = "https://github.com/matter-labs/zksync-crypto-gpu.gi
 
 tracing = "0.1"
 tracing-subscriber = "0.3"
+anyhow = "1"
 
 [profile.release.package."blake2_with_compression_verifier"]
 opt-level = 1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2026-02-10"

--- a/wrapper/Cargo.toml
+++ b/wrapper/Cargo.toml
@@ -27,6 +27,7 @@ clap.workspace = true
 sha3.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+anyhow.workspace = true
 
 shivini = { workspace = true, optional = true } 
 proof-compression = {workspace = true, optional = true}

--- a/wrapper/Cargo.toml
+++ b/wrapper/Cargo.toml
@@ -25,6 +25,8 @@ serde_json.workspace = true
 serde.workspace = true
 clap.workspace = true
 sha3.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 shivini = { workspace = true, optional = true } 
 proof-compression = {workspace = true, optional = true}

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -471,8 +471,10 @@ pub(crate) fn prepare_unrolled_proof_for_wrapper<
     WrappedProofSkeletonInstance<F>,
     [WrappedQueryValuesInstance<F>; NUM_QUERIES],
 ) {
-    let compiled_circuit: CompiledCircuitArtifact<Mersenne31Field> =
-        serde_json::from_str(include_str!("../inner_verifiers/unified_reduced/imports/circuit_layout.json")).unwrap();
+    let compiled_circuit: CompiledCircuitArtifact<Mersenne31Field> = serde_json::from_str(
+        include_str!("../inner_verifiers/unified_reduced/imports/circuit_layout.json"),
+    )
+    .unwrap();
 
     set_iterator_from_unrolled_proof(proof, compiled_circuit);
 
@@ -545,8 +547,10 @@ pub(crate) fn verify_risc_proof<V: LeafInclusionVerifier>(
     >,
     ProofPublicInputs<NUM_STATE_ELEMENTS>,
 ) {
-    let compiled_circuit: CompiledCircuitArtifact<Mersenne31Field> =
-        serde_json::from_str(include_str!("../inner_verifiers/unified_reduced/imports/circuit_layout.json")).unwrap();
+    let compiled_circuit: CompiledCircuitArtifact<Mersenne31Field> = serde_json::from_str(
+        include_str!("../inner_verifiers/unified_reduced/imports/circuit_layout.json"),
+    )
+    .unwrap();
 
     set_iterator_from_unrolled_proof(proof, compiled_circuit);
 

--- a/wrapper/src/gpu/compression.rs
+++ b/wrapper/src/gpu/compression.rs
@@ -72,7 +72,7 @@ pub fn get_compression_setup(
         )
         .unwrap();
 
-    println!(
+    tracing::info!(
         "compression circuit setup takes {} ms",
         start.elapsed().as_millis()
     );
@@ -135,7 +135,7 @@ pub fn prove_compression(
     )
     .unwrap();
 
-    println!(
+    tracing::info!(
         "compression wrapper proving takes {} ms",
         start.elapsed().as_millis()
     );

--- a/wrapper/src/gpu/risc_wrapper.rs
+++ b/wrapper/src/gpu/risc_wrapper.rs
@@ -20,7 +20,7 @@ use shivini::{
 
 use crate::{
     BinaryCommitment, RiscWrapper, RiscWrapperProof, RiscWrapperTranscript, RiscWrapperTreeHasher,
-    RiscWrapperVK, RiscWrapperWitness, StCircuitResolver
+    RiscWrapperVK, RiscWrapperWitness, StCircuitResolver,
 };
 
 type GL = GoldilocksField;
@@ -44,10 +44,11 @@ pub fn get_risc_wrapper_setup(
     let geometry = RiscWrapper::geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
 
-    let builder_impl = CsReferenceImplementationBuilder::<GL, GL, SetupCSConfig, StCircuitResolver<_, _>>::new(
-        geometry,
-        max_trace_len.unwrap(),
-    );
+    let builder_impl =
+        CsReferenceImplementationBuilder::<GL, GL, SetupCSConfig, StCircuitResolver<_, _>>::new(
+            geometry,
+            max_trace_len.unwrap(),
+        );
     let builder = new_builder::<_, GL>(builder_impl);
 
     let builder = RiscWrapper::configure_builder(builder);
@@ -76,7 +77,7 @@ pub fn get_risc_wrapper_setup(
         )
         .unwrap();
 
-    println!(
+    tracing::info!(
         "risc wrapper setup takes {} ms",
         start.elapsed().as_millis()
     );
@@ -107,10 +108,11 @@ pub fn prove_risc_wrapper(
     let geometry = RiscWrapper::geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
 
-    let builder_impl = CsReferenceImplementationBuilder::<GL, GL, ProvingCSConfig, StCircuitResolver<_, _>>::new(
-        geometry,
-        max_trace_len.unwrap(),
-    );
+    let builder_impl =
+        CsReferenceImplementationBuilder::<GL, GL, ProvingCSConfig, StCircuitResolver<_, _>>::new(
+            geometry,
+            max_trace_len.unwrap(),
+        );
     let builder = new_builder::<_, GL>(builder_impl);
 
     let builder = RiscWrapper::configure_builder(builder);
@@ -142,7 +144,7 @@ pub fn prove_risc_wrapper(
     )
     .unwrap();
 
-    println!(
+    tracing::info!(
         "risc wrapper proving takes {} ms",
         start.elapsed().as_millis()
     );

--- a/wrapper/src/gpu/snark.rs
+++ b/wrapper/src/gpu/snark.rs
@@ -154,7 +154,7 @@ pub fn gpu_snark_prove(
     assert!(proving_assembly.is_satisfied());
     assert!(finalization_hint.is_power_of_two());
     if use_zk {
-        println!("using zk (padding) proving");
+        tracing::info!("using zk (padding) proving");
         const NUM_PADDING_TERMS: usize = 2 + 2 + 2; // worst case witness polys are opened at 2 points, plus there are
         // indirect openings of grand product for permutation and for lookup
         let mut rng = rand::rngs::OsRng;
@@ -164,7 +164,7 @@ pub fn gpu_snark_prove(
             &mut rng,
         );
     } else {
-        println!("using non-zk (no padding) proving");
+        tracing::info!("using non-zk (no padding) proving");
         proving_assembly.finalize_to_size_log_2(finalization_hint.trailing_zeros() as usize);
     }
     let domain_size = proving_assembly.n() + 1;
@@ -181,7 +181,7 @@ pub fn gpu_snark_prove(
     >(&proving_assembly, &mut ctx, &worker, precomputation, None)
     .unwrap();
 
-    println!("plonk proving takes {} s", start.elapsed().as_secs());
+    tracing::info!("plonk proving takes {} s", start.elapsed().as_secs());
     ctx.free_all_slots();
 
     let result = zksync_gpu_prover::bellman::plonk::better_better_cs::verifier::verify::<

--- a/wrapper/src/interface/cmd.rs
+++ b/wrapper/src/interface/cmd.rs
@@ -1,0 +1,318 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[cfg(not(feature = "gpu"))]
+use super::utils::load_crs;
+#[cfg(not(feature = "gpu"))]
+use bellman::worker::Worker as BellmanWorker;
+
+use crate::{calculate_verification_key_hash, deserialize_from_file, serialize_to_file};
+
+use super::phases::{
+    VerifyStage, run_phase1_risc_wrapper, run_phase2_compression, run_phase3_snark,
+};
+use super::utils::{
+    create_boojum_worker, ensure_output_dir, load_binary_commitment, output_path, print_elapsed,
+};
+
+// ==============================================================================
+// Public Command Entry Points
+// ==============================================================================
+//
+// These functions represent the "commands" that can be done via CLI; you can
+// treat them as reusable high-level entrypoints. However, outside of CLI-like
+// utilities, it is recommended to use `phases` module directly instead.
+
+pub fn cmd_prove_all(
+    proof: PathBuf,
+    bin: Option<PathBuf>,
+    text: Option<PathBuf>,
+    output_dir: PathBuf,
+    trusted_setup: Option<PathBuf>,
+    use_zk: bool,
+    save_intermediates: bool,
+    threads: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_output_dir(&output_dir)?;
+    let total_start = Instant::now();
+    let worker = create_boojum_worker(threads);
+
+    // Drive the full pipeline in order so callers can optionally persist the
+    // boundaries between phases for later debugging or reuse.
+    let (risc_wrapper_proof, risc_wrapper_vk) =
+        run_phase1_risc_wrapper(&proof, &bin, &text, &worker)?;
+
+    if save_intermediates {
+        serialize_to_file(
+            &risc_wrapper_proof,
+            &output_path(&output_dir, "risc_wrapper_proof.json"),
+        );
+        serialize_to_file(
+            &risc_wrapper_vk,
+            &output_path(&output_dir, "risc_wrapper_vk.json"),
+        );
+        tracing::info!("Saved intermediate Phase 1 outputs");
+    }
+
+    let (compression_proof, compression_vk) =
+        run_phase2_compression(risc_wrapper_proof, risc_wrapper_vk, &worker)?;
+
+    if save_intermediates {
+        serialize_to_file(
+            &compression_proof,
+            &output_path(&output_dir, "compression_proof.json"),
+        );
+        serialize_to_file(
+            &compression_vk,
+            &output_path(&output_dir, "compression_vk.json"),
+        );
+        tracing::info!("Saved intermediate Phase 2 outputs");
+    }
+
+    let (snark_proof, snark_vk) =
+        run_phase3_snark(compression_proof, compression_vk, &trusted_setup, use_zk)?;
+
+    serialize_to_file(&snark_proof, &output_path(&output_dir, "snark_proof.json"));
+    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
+
+    let vk_hash = calculate_verification_key_hash(snark_vk);
+    tracing::info!("SNARK VK hash: {vk_hash:?}");
+
+    let total_elapsed = total_start.elapsed();
+    tracing::info!(
+        "=== Total pipeline time: {:.1}s",
+        total_elapsed.as_secs_f64()
+    );
+
+    Ok(())
+}
+
+pub fn cmd_prove_risc_wrapper(
+    proof: PathBuf,
+    bin: Option<PathBuf>,
+    text: Option<PathBuf>,
+    output_dir: PathBuf,
+    threads: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_output_dir(&output_dir)?;
+    let worker = create_boojum_worker(threads);
+
+    let (risc_wrapper_proof, risc_wrapper_vk) =
+        run_phase1_risc_wrapper(&proof, &bin, &text, &worker)?;
+
+    serialize_to_file(
+        &risc_wrapper_proof,
+        &output_path(&output_dir, "risc_wrapper_proof.json"),
+    );
+    serialize_to_file(
+        &risc_wrapper_vk,
+        &output_path(&output_dir, "risc_wrapper_vk.json"),
+    );
+
+    Ok(())
+}
+
+pub fn cmd_prove_compression(
+    risc_wrapper_proof_path: PathBuf,
+    risc_wrapper_vk_path: PathBuf,
+    output_dir: PathBuf,
+    threads: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_output_dir(&output_dir)?;
+    let worker = create_boojum_worker(threads);
+
+    tracing::info!(
+        "Loading RISC wrapper proof from {}",
+        risc_wrapper_proof_path.display()
+    );
+    let risc_wrapper_proof = deserialize_from_file(risc_wrapper_proof_path.to_str().unwrap());
+    tracing::info!(
+        "Loading RISC wrapper VK from {}",
+        risc_wrapper_vk_path.display()
+    );
+    let risc_wrapper_vk = deserialize_from_file(risc_wrapper_vk_path.to_str().unwrap());
+
+    let (compression_proof, compression_vk) =
+        run_phase2_compression(risc_wrapper_proof, risc_wrapper_vk, &worker)?;
+
+    serialize_to_file(
+        &compression_proof,
+        &output_path(&output_dir, "compression_proof.json"),
+    );
+    serialize_to_file(
+        &compression_vk,
+        &output_path(&output_dir, "compression_vk.json"),
+    );
+
+    Ok(())
+}
+
+pub fn cmd_prove_snark(
+    compression_proof_path: PathBuf,
+    compression_vk_path: PathBuf,
+    output_dir: PathBuf,
+    trusted_setup: Option<PathBuf>,
+    use_zk: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_output_dir(&output_dir)?;
+
+    tracing::info!(
+        "Loading compression proof from {}",
+        compression_proof_path.display()
+    );
+    let compression_proof = deserialize_from_file(compression_proof_path.to_str().unwrap());
+    tracing::info!(
+        "Loading compression VK from {}",
+        compression_vk_path.display()
+    );
+    let compression_vk = deserialize_from_file(compression_vk_path.to_str().unwrap());
+
+    let (snark_proof, snark_vk) =
+        run_phase3_snark(compression_proof, compression_vk, &trusted_setup, use_zk)?;
+
+    serialize_to_file(&snark_proof, &output_path(&output_dir, "snark_proof.json"));
+    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
+
+    let vk_hash = calculate_verification_key_hash(snark_vk);
+    tracing::info!("SNARK VK hash: {vk_hash:?}");
+
+    Ok(())
+}
+
+pub fn cmd_generate_vk(
+    output_dir: PathBuf,
+    bin: Option<PathBuf>,
+    text: Option<PathBuf>,
+    trusted_setup: Option<PathBuf>,
+    threads: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_output_dir(&output_dir)?;
+    let worker = create_boojum_worker(threads);
+
+    // Build the verification key chain directly without requiring a proof input.
+    tracing::info!("=== VK generation - binary commitment: starting...");
+    let start = Instant::now();
+    let binary_commitment = load_binary_commitment(&bin, &text)?;
+    print_elapsed("VK generation - binary commitment", start);
+
+    tracing::info!("=== VK generation - Phase 1 (RISC wrapper): starting...");
+    let start = Instant::now();
+    #[cfg(not(feature = "gpu"))]
+    let risc_wrapper_vk = {
+        let (_, _, _, risc_wrapper_vk, _, _, _) =
+            crate::get_risc_wrapper_setup(&worker, binary_commitment);
+        risc_wrapper_vk
+    };
+    #[cfg(feature = "gpu")]
+    let risc_wrapper_vk = {
+        let (_, gpu_vk, _) =
+            crate::gpu::risc_wrapper::get_risc_wrapper_setup(&worker, binary_commitment);
+        gpu_vk
+    };
+    print_elapsed("VK generation - Phase 1 (RISC wrapper)", start);
+    serialize_to_file(
+        &risc_wrapper_vk,
+        &output_path(&output_dir, "risc_wrapper_vk.json"),
+    );
+    tracing::info!("Saved risc_wrapper_vk.json");
+
+    tracing::info!("=== VK generation - Phase 2 (compression): starting...");
+    let start = Instant::now();
+    #[cfg(not(feature = "gpu"))]
+    let compression_vk = {
+        let (_, _, _, compression_vk, _, _, _) =
+            crate::get_compression_setup(risc_wrapper_vk, &worker);
+        compression_vk
+    };
+    #[cfg(feature = "gpu")]
+    let compression_vk = {
+        let config =
+            shivini::ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+        let _prover_context = shivini::ProverContext::create_with_config(config).unwrap();
+
+        let (_, gpu_vk, _) =
+            crate::gpu::compression::get_compression_setup(&worker, risc_wrapper_vk);
+        gpu_vk
+    };
+    print_elapsed("VK generation - Phase 2 (compression)", start);
+    serialize_to_file(
+        &compression_vk,
+        &output_path(&output_dir, "compression_vk.json"),
+    );
+    tracing::info!("Saved compression_vk.json");
+
+    tracing::info!("=== VK generation - Phase 3 (SNARK): starting...");
+    let start = Instant::now();
+    #[cfg(not(feature = "gpu"))]
+    let snark_vk = {
+        let crs_mons = load_crs(&trusted_setup);
+        let bellman_worker = BellmanWorker::new();
+        let (_, snark_vk) =
+            crate::get_snark_wrapper_setup(compression_vk, &crs_mons, &bellman_worker);
+        snark_vk
+    };
+    #[cfg(feature = "gpu")]
+    let snark_vk = {
+        let crs_file = trusted_setup
+            .as_ref()
+            .expect("GPU VK generation requires a trusted setup file path (--trusted-setup)")
+            .to_string_lossy()
+            .to_string();
+        let (_, snark_vk) =
+            crate::gpu::snark::gpu_create_snark_setup_data(&compression_vk, &crs_file);
+        snark_vk
+    };
+    print_elapsed("VK generation - Phase 3 (SNARK)", start);
+    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
+    tracing::info!("Saved snark_vk.json");
+
+    let vk_hash = calculate_verification_key_hash(snark_vk);
+    tracing::info!("SNARK VK hash: {vk_hash:?}");
+
+    Ok(())
+}
+
+pub fn cmd_vk_hash(vk_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    tracing::info!("Loading VK from {}", vk_path.display());
+    let vk = deserialize_from_file(vk_path.to_str().unwrap());
+    let vk_hash = calculate_verification_key_hash(vk);
+    tracing::info!("SNARK VK hash: {vk_hash:?}");
+    Ok(())
+}
+
+pub fn cmd_verify(
+    stage: VerifyStage,
+    proof_path: PathBuf,
+    vk_path: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let proof_str = proof_path.to_str().unwrap();
+    let vk_str = vk_path.to_str().unwrap();
+
+    let is_valid = match stage {
+        VerifyStage::RiscWrapper => {
+            tracing::info!("Verifying RISC wrapper proof...");
+            let proof = deserialize_from_file(proof_str);
+            let vk = deserialize_from_file(vk_str);
+            crate::verify_risc_wrapper_proof(&proof, &vk)
+        }
+        VerifyStage::Compression => {
+            tracing::info!("Verifying compression proof...");
+            let proof = deserialize_from_file(proof_str);
+            let vk = deserialize_from_file(vk_str);
+            crate::verify_compression_proof(&proof, &vk)
+        }
+        VerifyStage::Snark => {
+            tracing::info!("Verifying SNARK proof...");
+            let proof = deserialize_from_file(proof_str);
+            let vk = deserialize_from_file(vk_str);
+            crate::verify_snark_wrapper_proof(&proof, &vk)
+        }
+    };
+
+    if is_valid {
+        tracing::info!("Proof is VALID");
+        Ok(())
+    } else {
+        Err("Proof verification FAILED".into())
+    }
+}

--- a/wrapper/src/interface/cmd.rs
+++ b/wrapper/src/interface/cmd.rs
@@ -12,7 +12,8 @@ use super::phases::{
     VerifyStage, run_phase1_risc_wrapper, run_phase2_compression, run_phase3_snark,
 };
 use super::utils::{
-    create_boojum_worker, ensure_output_dir, load_binary_commitment, output_path, print_elapsed,
+    create_boojum_worker, ensure_output_dir, load_binary_commitment, load_proof, output_path,
+    print_elapsed,
 };
 
 // ==============================================================================
@@ -36,11 +37,12 @@ pub fn cmd_prove_all(
     ensure_output_dir(&output_dir)?;
     let total_start = Instant::now();
     let worker = create_boojum_worker(threads);
+    let program_proof = load_proof(&proof);
 
     // Drive the full pipeline in order so callers can optionally persist the
     // boundaries between phases for later debugging or reuse.
     let (risc_wrapper_proof, risc_wrapper_vk) =
-        run_phase1_risc_wrapper(&proof, &bin, &text, &worker)?;
+        run_phase1_risc_wrapper(program_proof, &bin, &text, &worker)?;
 
     if save_intermediates {
         serialize_to_file(
@@ -96,9 +98,10 @@ pub fn cmd_prove_risc_wrapper(
 ) -> Result<(), Box<dyn std::error::Error>> {
     ensure_output_dir(&output_dir)?;
     let worker = create_boojum_worker(threads);
+    let program_proof = load_proof(&proof);
 
     let (risc_wrapper_proof, risc_wrapper_vk) =
-        run_phase1_risc_wrapper(&proof, &bin, &text, &worker)?;
+        run_phase1_risc_wrapper(program_proof, &bin, &text, &worker)?;
 
     serialize_to_file(
         &risc_wrapper_proof,

--- a/wrapper/src/interface/cmd.rs
+++ b/wrapper/src/interface/cmd.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
+use anyhow::Context as _;
+
 #[cfg(not(feature = "gpu"))]
 use super::utils::load_crs;
 #[cfg(not(feature = "gpu"))]
@@ -33,11 +35,11 @@ pub fn cmd_prove_all(
     use_zk: bool,
     save_intermediates: bool,
     threads: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
     let total_start = Instant::now();
     let worker = create_boojum_worker(threads);
-    let program_proof = load_proof(&proof);
+    let program_proof = load_proof(&proof).context("Can't load the proof")?;
 
     // Drive the full pipeline in order so callers can optionally persist the
     // boundaries between phases for later debugging or reuse.
@@ -48,11 +50,11 @@ pub fn cmd_prove_all(
         serialize_to_file(
             &risc_wrapper_proof,
             &output_path(&output_dir, "risc_wrapper_proof.json"),
-        );
+        )?;
         serialize_to_file(
             &risc_wrapper_vk,
             &output_path(&output_dir, "risc_wrapper_vk.json"),
-        );
+        )?;
         tracing::info!("Saved intermediate Phase 1 outputs");
     }
 
@@ -63,19 +65,19 @@ pub fn cmd_prove_all(
         serialize_to_file(
             &compression_proof,
             &output_path(&output_dir, "compression_proof.json"),
-        );
+        )?;
         serialize_to_file(
             &compression_vk,
             &output_path(&output_dir, "compression_vk.json"),
-        );
+        )?;
         tracing::info!("Saved intermediate Phase 2 outputs");
     }
 
     let (snark_proof, snark_vk) =
         run_phase3_snark(compression_proof, compression_vk, &trusted_setup, use_zk)?;
 
-    serialize_to_file(&snark_proof, &output_path(&output_dir, "snark_proof.json"));
-    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
+    serialize_to_file(&snark_proof, &output_path(&output_dir, "snark_proof.json"))?;
+    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"))?;
 
     let vk_hash = calculate_verification_key_hash(snark_vk);
     tracing::info!("SNARK VK hash: {vk_hash:?}");
@@ -95,10 +97,10 @@ pub fn cmd_prove_risc_wrapper(
     text: Option<PathBuf>,
     output_dir: PathBuf,
     threads: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
     let worker = create_boojum_worker(threads);
-    let program_proof = load_proof(&proof);
+    let program_proof = load_proof(&proof).context("Can't load the proof")?;
 
     let (risc_wrapper_proof, risc_wrapper_vk) =
         run_phase1_risc_wrapper(program_proof, &bin, &text, &worker)?;
@@ -106,11 +108,11 @@ pub fn cmd_prove_risc_wrapper(
     serialize_to_file(
         &risc_wrapper_proof,
         &output_path(&output_dir, "risc_wrapper_proof.json"),
-    );
+    )?;
     serialize_to_file(
         &risc_wrapper_vk,
         &output_path(&output_dir, "risc_wrapper_vk.json"),
-    );
+    )?;
 
     Ok(())
 }
@@ -120,7 +122,7 @@ pub fn cmd_prove_compression(
     risc_wrapper_vk_path: PathBuf,
     output_dir: PathBuf,
     threads: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
     let worker = create_boojum_worker(threads);
 
@@ -128,12 +130,14 @@ pub fn cmd_prove_compression(
         "Loading RISC wrapper proof from {}",
         risc_wrapper_proof_path.display()
     );
-    let risc_wrapper_proof = deserialize_from_file(risc_wrapper_proof_path.to_str().unwrap());
+    let risc_wrapper_proof = deserialize_from_file(risc_wrapper_proof_path.to_str().unwrap())
+        .context("risk_wrapper_proof")?;
     tracing::info!(
         "Loading RISC wrapper VK from {}",
         risc_wrapper_vk_path.display()
     );
-    let risc_wrapper_vk = deserialize_from_file(risc_wrapper_vk_path.to_str().unwrap());
+    let risc_wrapper_vk =
+        deserialize_from_file(risc_wrapper_vk_path.to_str().unwrap()).context("risk_wrapper_vk")?;
 
     let (compression_proof, compression_vk) =
         run_phase2_compression(risc_wrapper_proof, risc_wrapper_vk, &worker)?;
@@ -141,11 +145,11 @@ pub fn cmd_prove_compression(
     serialize_to_file(
         &compression_proof,
         &output_path(&output_dir, "compression_proof.json"),
-    );
+    )?;
     serialize_to_file(
         &compression_vk,
         &output_path(&output_dir, "compression_vk.json"),
-    );
+    )?;
 
     Ok(())
 }
@@ -156,25 +160,27 @@ pub fn cmd_prove_snark(
     output_dir: PathBuf,
     trusted_setup: Option<PathBuf>,
     use_zk: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
 
     tracing::info!(
         "Loading compression proof from {}",
         compression_proof_path.display()
     );
-    let compression_proof = deserialize_from_file(compression_proof_path.to_str().unwrap());
+    let compression_proof = deserialize_from_file(compression_proof_path.to_str().unwrap())
+        .context("compression proof")?;
     tracing::info!(
         "Loading compression VK from {}",
         compression_vk_path.display()
     );
-    let compression_vk = deserialize_from_file(compression_vk_path.to_str().unwrap());
+    let compression_vk =
+        deserialize_from_file(compression_vk_path.to_str().unwrap()).context("compression vk")?;
 
     let (snark_proof, snark_vk) =
         run_phase3_snark(compression_proof, compression_vk, &trusted_setup, use_zk)?;
 
-    serialize_to_file(&snark_proof, &output_path(&output_dir, "snark_proof.json"));
-    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
+    serialize_to_file(&snark_proof, &output_path(&output_dir, "snark_proof.json"))?;
+    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"))?;
 
     let vk_hash = calculate_verification_key_hash(snark_vk);
     tracing::info!("SNARK VK hash: {vk_hash:?}");
@@ -188,14 +194,14 @@ pub fn cmd_generate_vk(
     text: Option<PathBuf>,
     trusted_setup: Option<PathBuf>,
     threads: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
     let worker = create_boojum_worker(threads);
 
     // Build the verification key chain directly without requiring a proof input.
     tracing::info!("=== VK generation - binary commitment: starting...");
     let start = Instant::now();
-    let binary_commitment = load_binary_commitment(&bin, &text)?;
+    let binary_commitment = load_binary_commitment(&bin, &text).context("binary commitment")?;
     print_elapsed("VK generation - binary commitment", start);
 
     tracing::info!("=== VK generation - Phase 1 (RISC wrapper): starting...");
@@ -216,7 +222,7 @@ pub fn cmd_generate_vk(
     serialize_to_file(
         &risc_wrapper_vk,
         &output_path(&output_dir, "risc_wrapper_vk.json"),
-    );
+    )?;
     tracing::info!("Saved risc_wrapper_vk.json");
 
     tracing::info!("=== VK generation - Phase 2 (compression): starting...");
@@ -241,14 +247,14 @@ pub fn cmd_generate_vk(
     serialize_to_file(
         &compression_vk,
         &output_path(&output_dir, "compression_vk.json"),
-    );
+    )?;
     tracing::info!("Saved compression_vk.json");
 
     tracing::info!("=== VK generation - Phase 3 (SNARK): starting...");
     let start = Instant::now();
     #[cfg(not(feature = "gpu"))]
     let snark_vk = {
-        let crs_mons = load_crs(&trusted_setup);
+        let crs_mons = load_crs(&trusted_setup)?;
         let bellman_worker = BellmanWorker::new();
         let (_, snark_vk) =
             crate::get_snark_wrapper_setup(compression_vk, &crs_mons, &bellman_worker);
@@ -266,7 +272,7 @@ pub fn cmd_generate_vk(
         snark_vk
     };
     print_elapsed("VK generation - Phase 3 (SNARK)", start);
-    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
+    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"))?;
     tracing::info!("Saved snark_vk.json");
 
     let vk_hash = calculate_verification_key_hash(snark_vk);
@@ -275,39 +281,35 @@ pub fn cmd_generate_vk(
     Ok(())
 }
 
-pub fn cmd_vk_hash(vk_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+pub fn cmd_vk_hash(vk_path: PathBuf) -> anyhow::Result<()> {
     tracing::info!("Loading VK from {}", vk_path.display());
-    let vk = deserialize_from_file(vk_path.to_str().unwrap());
+    let vk = deserialize_from_file(vk_path.to_str().unwrap())?;
     let vk_hash = calculate_verification_key_hash(vk);
     tracing::info!("SNARK VK hash: {vk_hash:?}");
     Ok(())
 }
 
-pub fn cmd_verify(
-    stage: VerifyStage,
-    proof_path: PathBuf,
-    vk_path: PathBuf,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn cmd_verify(stage: VerifyStage, proof_path: PathBuf, vk_path: PathBuf) -> anyhow::Result<()> {
     let proof_str = proof_path.to_str().unwrap();
     let vk_str = vk_path.to_str().unwrap();
 
     let is_valid = match stage {
         VerifyStage::RiscWrapper => {
             tracing::info!("Verifying RISC wrapper proof...");
-            let proof = deserialize_from_file(proof_str);
-            let vk = deserialize_from_file(vk_str);
+            let proof = deserialize_from_file(proof_str).context("proof")?;
+            let vk = deserialize_from_file(vk_str).context("vk")?;
             crate::verify_risc_wrapper_proof(&proof, &vk)
         }
         VerifyStage::Compression => {
             tracing::info!("Verifying compression proof...");
-            let proof = deserialize_from_file(proof_str);
-            let vk = deserialize_from_file(vk_str);
+            let proof = deserialize_from_file(proof_str).context("proof")?;
+            let vk = deserialize_from_file(vk_str).context("vk")?;
             crate::verify_compression_proof(&proof, &vk)
         }
         VerifyStage::Snark => {
             tracing::info!("Verifying SNARK proof...");
-            let proof = deserialize_from_file(proof_str);
-            let vk = deserialize_from_file(vk_str);
+            let proof = deserialize_from_file(proof_str).context("proof")?;
+            let vk = deserialize_from_file(vk_str).context("vk")?;
             crate::verify_snark_wrapper_proof(&proof, &vk)
         }
     };
@@ -316,6 +318,6 @@ pub fn cmd_verify(
         tracing::info!("Proof is VALID");
         Ok(())
     } else {
-        Err("Proof verification FAILED".into())
+        Err(anyhow::anyhow!("Proof verification FAILED"))
     }
 }

--- a/wrapper/src/interface/mod.rs
+++ b/wrapper/src/interface/mod.rs
@@ -1,0 +1,11 @@
+mod cmd;
+mod phases;
+mod utils;
+
+pub use self::cmd::{
+    cmd_generate_vk, cmd_prove_all, cmd_prove_compression, cmd_prove_risc_wrapper, cmd_prove_snark,
+    cmd_verify, cmd_vk_hash,
+};
+pub use self::phases::{
+    VerifyStage, run_phase1_risc_wrapper, run_phase2_compression, run_phase3_snark,
+};

--- a/wrapper/src/interface/phases.rs
+++ b/wrapper/src/interface/phases.rs
@@ -20,14 +20,6 @@ pub enum VerifyStage {
     Snark,
 }
 
-// ==============================================================================
-// Pipeline Phase Implementations
-// ==============================================================================
-//
-// Each phase function owns one boundary in the wrapper pipeline. The command
-// layer is responsible for CLI-oriented concerns such as paths and persistence,
-// while this module focuses on the actual proving, setup, and verification flow.
-
 pub fn run_phase1_risc_wrapper(
     program_proof: UnrolledProgramProof,
     bin: &Option<PathBuf>,

--- a/wrapper/src/interface/phases.rs
+++ b/wrapper/src/interface/phases.rs
@@ -1,0 +1,273 @@
+use boojum::worker::Worker as BoojumWorker;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+#[cfg(not(feature = "gpu"))]
+use super::utils::load_crs;
+#[cfg(not(feature = "gpu"))]
+use bellman::worker::Worker as BellmanWorker;
+
+use crate::circuits::RiscWrapperWitness;
+use crate::deserialize_from_file;
+
+use super::utils::{load_binary_commitment, print_elapsed};
+
+#[derive(Clone)]
+pub enum VerifyStage {
+    RiscWrapper,
+    Compression,
+    Snark,
+}
+
+// ==============================================================================
+// Pipeline Phase Implementations
+// ==============================================================================
+//
+// Each phase function owns one boundary in the wrapper pipeline. The command
+// layer is responsible for CLI-oriented concerns such as paths and persistence,
+// while this module focuses on the actual proving, setup, and verification flow.
+
+pub fn run_phase1_risc_wrapper(
+    proof_path: &Path,
+    bin: &Option<PathBuf>,
+    text: &Option<PathBuf>,
+    worker: &BoojumWorker,
+) -> Result<(crate::RiscWrapperProof, crate::RiscWrapperVK), Box<dyn std::error::Error>> {
+    tracing::info!("=== Phase 1 - binary commitment: starting...");
+    let start = Instant::now();
+    let binary_commitment = load_binary_commitment(bin, text)?;
+    print_elapsed("Phase 1 - binary commitment", start);
+
+    tracing::info!("Loading FRI proof from {}", proof_path.display());
+    let program_proof: execution_utils::unrolled::UnrolledProgramProof =
+        deserialize_from_file(proof_path.to_str().unwrap());
+
+    tracing::info!("=== Phase 1 - witness generation: starting...");
+    let start = Instant::now();
+    let risc_wrapper_witness =
+        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment);
+    print_elapsed("Phase 1 - witness generation", start);
+
+    #[cfg(not(feature = "gpu"))]
+    let (risc_wrapper_proof, risc_wrapper_vk) = {
+        tracing::info!("=== Phase 1 - setup (CPU): starting...");
+        let start = Instant::now();
+        let (
+            finalization_hint,
+            setup_base,
+            setup,
+            risc_wrapper_vk,
+            setup_tree,
+            vars_hint,
+            witness_hints,
+        ) = crate::get_risc_wrapper_setup(worker, binary_commitment.clone());
+        print_elapsed("Phase 1 - setup (CPU)", start);
+
+        tracing::info!("=== Phase 1 - prove (CPU): starting...");
+        let start = Instant::now();
+        let risc_wrapper_proof = crate::prove_risc_wrapper(
+            risc_wrapper_witness,
+            &finalization_hint,
+            &setup_base,
+            &setup,
+            &risc_wrapper_vk,
+            &setup_tree,
+            &vars_hint,
+            &witness_hints,
+            worker,
+            binary_commitment,
+        );
+        print_elapsed("Phase 1 - prove (CPU)", start);
+
+        (risc_wrapper_proof, risc_wrapper_vk)
+    };
+
+    #[cfg(feature = "gpu")]
+    let (risc_wrapper_proof, risc_wrapper_vk) = {
+        tracing::info!("=== Phase 1 - setup (GPU): starting...");
+        let start = Instant::now();
+        let (gpu_setup, gpu_vk, finalization_hint) =
+            crate::gpu::risc_wrapper::get_risc_wrapper_setup(worker, binary_commitment.clone());
+        print_elapsed("Phase 1 - setup (GPU)", start);
+
+        tracing::info!("=== Phase 1 - prove (GPU): starting...");
+        let start = Instant::now();
+        let risc_wrapper_proof = crate::gpu::risc_wrapper::prove_risc_wrapper(
+            risc_wrapper_witness,
+            &finalization_hint,
+            &gpu_setup,
+            &gpu_vk,
+            worker,
+            binary_commitment,
+        );
+        print_elapsed("Phase 1 - prove (GPU)", start);
+
+        (risc_wrapper_proof, gpu_vk)
+    };
+
+    tracing::info!("=== Phase 1 - verify: starting...");
+    let start = Instant::now();
+    let is_valid = crate::verify_risc_wrapper_proof(&risc_wrapper_proof, &risc_wrapper_vk);
+    print_elapsed("Phase 1 - verify", start);
+    if !is_valid {
+        return Err("RISC wrapper proof verification failed".into());
+    }
+    tracing::info!("Phase 1 proof verified successfully");
+
+    Ok((risc_wrapper_proof, risc_wrapper_vk))
+}
+
+pub fn run_phase2_compression(
+    risc_wrapper_proof: crate::RiscWrapperProof,
+    risc_wrapper_vk: crate::RiscWrapperVK,
+    worker: &BoojumWorker,
+) -> Result<(crate::CompressionProof, crate::CompressionVK), Box<dyn std::error::Error>> {
+    #[cfg(not(feature = "gpu"))]
+    let (compression_proof, compression_vk) = {
+        tracing::info!("=== Phase 2 - setup (CPU): starting...");
+        let start = Instant::now();
+        let (
+            finalization_hint,
+            setup_base,
+            setup,
+            compression_vk,
+            setup_tree,
+            vars_hint,
+            witness_hints,
+        ) = crate::get_compression_setup(risc_wrapper_vk.clone(), worker);
+        print_elapsed("Phase 2 - setup (CPU)", start);
+
+        tracing::info!("=== Phase 2 - prove (CPU): starting...");
+        let start = Instant::now();
+        let compression_proof = crate::prove_compression(
+            risc_wrapper_proof,
+            risc_wrapper_vk,
+            &finalization_hint,
+            &setup_base,
+            &setup,
+            &compression_vk,
+            &setup_tree,
+            &vars_hint,
+            &witness_hints,
+            worker,
+        );
+        print_elapsed("Phase 2 - prove (CPU)", start);
+
+        (compression_proof, compression_vk)
+    };
+
+    #[cfg(feature = "gpu")]
+    let (compression_proof, compression_vk) = {
+        let config =
+            shivini::ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+        let _prover_context = shivini::ProverContext::create_with_config(config).unwrap();
+
+        tracing::info!("=== Phase 2 - setup (GPU): starting...");
+        let start = Instant::now();
+        let (gpu_setup, gpu_vk, finalization_hint) =
+            crate::gpu::compression::get_compression_setup(worker, risc_wrapper_vk.clone());
+        print_elapsed("Phase 2 - setup (GPU)", start);
+
+        tracing::info!("=== Phase 2 - prove (GPU): starting...");
+        let start = Instant::now();
+        let compression_proof = crate::gpu::compression::prove_compression(
+            risc_wrapper_proof,
+            risc_wrapper_vk,
+            &finalization_hint,
+            &gpu_setup,
+            &gpu_vk,
+            worker,
+        );
+        print_elapsed("Phase 2 - prove (GPU)", start);
+
+        (compression_proof, gpu_vk)
+    };
+
+    tracing::info!("=== Phase 2 - verify: starting...");
+    let start = Instant::now();
+    let is_valid = crate::verify_compression_proof(&compression_proof, &compression_vk);
+    print_elapsed("Phase 2 - verify", start);
+    if !is_valid {
+        return Err("Compression proof verification failed".into());
+    }
+    tracing::info!("Phase 2 proof verified successfully");
+
+    Ok((compression_proof, compression_vk))
+}
+
+pub fn run_phase3_snark(
+    compression_proof: crate::CompressionProof,
+    compression_vk: crate::CompressionVK,
+    trusted_setup: &Option<PathBuf>,
+    use_zk: bool,
+) -> Result<(crate::SnarkWrapperProof, crate::SnarkWrapperVK), Box<dyn std::error::Error>> {
+    #[cfg(not(feature = "gpu"))]
+    let (snark_proof, snark_vk) = {
+        tracing::info!("=== Phase 3 - load CRS: starting...");
+        let start = Instant::now();
+        let crs_mons = load_crs(trusted_setup);
+        print_elapsed("Phase 3 - load CRS", start);
+
+        let bellman_worker = BellmanWorker::new();
+
+        tracing::info!("=== Phase 3 - setup (CPU): starting...");
+        let start = Instant::now();
+        let (snark_setup, snark_vk) =
+            crate::get_snark_wrapper_setup(compression_vk.clone(), &crs_mons, &bellman_worker);
+        print_elapsed("Phase 3 - setup (CPU)", start);
+
+        tracing::info!("=== Phase 3 - prove (CPU): starting...");
+        let start = Instant::now();
+        let snark_proof = crate::prove_snark_wrapper(
+            compression_proof,
+            compression_vk,
+            &snark_setup,
+            &crs_mons,
+            &bellman_worker,
+            use_zk,
+        );
+        print_elapsed("Phase 3 - prove (CPU)", start);
+
+        (snark_proof, snark_vk)
+    };
+
+    #[cfg(feature = "gpu")]
+    let (snark_proof, snark_vk) = {
+        let crs_file = trusted_setup
+            .as_ref()
+            .expect("GPU SNARK proving requires a trusted setup file path (--trusted-setup)")
+            .to_string_lossy()
+            .to_string();
+
+        tracing::info!("=== Phase 3 - setup (GPU): starting...");
+        let start = Instant::now();
+        let (precomputation, snark_vk) =
+            crate::gpu::snark::gpu_create_snark_setup_data(&compression_vk, &crs_file);
+        print_elapsed("Phase 3 - setup (GPU)", start);
+
+        tracing::info!("=== Phase 3 - prove (GPU): starting...");
+        let start = Instant::now();
+        let snark_proof = crate::gpu::snark::gpu_snark_prove(
+            &precomputation,
+            &snark_vk,
+            compression_proof,
+            compression_vk,
+            &crs_file,
+            use_zk,
+        );
+        print_elapsed("Phase 3 - prove (GPU)", start);
+
+        (snark_proof, snark_vk)
+    };
+
+    tracing::info!("=== Phase 3 - verify: starting...");
+    let start = Instant::now();
+    let is_valid = crate::verify_snark_wrapper_proof(&snark_proof, &snark_vk);
+    print_elapsed("Phase 3 - verify", start);
+    if !is_valid {
+        return Err("SNARK wrapper proof verification failed".into());
+    }
+    tracing::info!("Phase 3 proof verified successfully");
+
+    Ok((snark_proof, snark_vk))
+}

--- a/wrapper/src/interface/phases.rs
+++ b/wrapper/src/interface/phases.rs
@@ -1,5 +1,6 @@
 use boojum::worker::Worker as BoojumWorker;
-use std::path::{Path, PathBuf};
+use execution_utils::unrolled::UnrolledProgramProof;
+use std::path::PathBuf;
 use std::time::Instant;
 
 #[cfg(not(feature = "gpu"))]
@@ -8,7 +9,6 @@ use super::utils::load_crs;
 use bellman::worker::Worker as BellmanWorker;
 
 use crate::circuits::RiscWrapperWitness;
-use crate::deserialize_from_file;
 
 use super::utils::{load_binary_commitment, print_elapsed};
 
@@ -28,7 +28,7 @@ pub enum VerifyStage {
 // while this module focuses on the actual proving, setup, and verification flow.
 
 pub fn run_phase1_risc_wrapper(
-    proof_path: &Path,
+    program_proof: UnrolledProgramProof,
     bin: &Option<PathBuf>,
     text: &Option<PathBuf>,
     worker: &BoojumWorker,
@@ -37,10 +37,6 @@ pub fn run_phase1_risc_wrapper(
     let start = Instant::now();
     let binary_commitment = load_binary_commitment(bin, text)?;
     print_elapsed("Phase 1 - binary commitment", start);
-
-    tracing::info!("Loading FRI proof from {}", proof_path.display());
-    let program_proof: execution_utils::unrolled::UnrolledProgramProof =
-        deserialize_from_file(proof_path.to_str().unwrap());
 
     tracing::info!("=== Phase 1 - witness generation: starting...");
     let start = Instant::now();

--- a/wrapper/src/interface/phases.rs
+++ b/wrapper/src/interface/phases.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use boojum::worker::Worker as BoojumWorker;
 use execution_utils::unrolled::UnrolledProgramProof;
 use std::path::PathBuf;
@@ -32,7 +33,7 @@ pub fn run_phase1_risc_wrapper(
     bin: &Option<PathBuf>,
     text: &Option<PathBuf>,
     worker: &BoojumWorker,
-) -> Result<(crate::RiscWrapperProof, crate::RiscWrapperVK), Box<dyn std::error::Error>> {
+) -> anyhow::Result<(crate::RiscWrapperProof, crate::RiscWrapperVK)> {
     tracing::info!("=== Phase 1 - binary commitment: starting...");
     let start = Instant::now();
     let binary_commitment = load_binary_commitment(bin, text)?;
@@ -106,7 +107,7 @@ pub fn run_phase1_risc_wrapper(
     let is_valid = crate::verify_risc_wrapper_proof(&risc_wrapper_proof, &risc_wrapper_vk);
     print_elapsed("Phase 1 - verify", start);
     if !is_valid {
-        return Err("RISC wrapper proof verification failed".into());
+        return Err(anyhow::anyhow!("RISC wrapper proof verification failed"));
     }
     tracing::info!("Phase 1 proof verified successfully");
 
@@ -117,7 +118,7 @@ pub fn run_phase2_compression(
     risc_wrapper_proof: crate::RiscWrapperProof,
     risc_wrapper_vk: crate::RiscWrapperVK,
     worker: &BoojumWorker,
-) -> Result<(crate::CompressionProof, crate::CompressionVK), Box<dyn std::error::Error>> {
+) -> anyhow::Result<(crate::CompressionProof, crate::CompressionVK)> {
     #[cfg(not(feature = "gpu"))]
     let (compression_proof, compression_vk) = {
         tracing::info!("=== Phase 2 - setup (CPU): starting...");
@@ -184,7 +185,7 @@ pub fn run_phase2_compression(
     let is_valid = crate::verify_compression_proof(&compression_proof, &compression_vk);
     print_elapsed("Phase 2 - verify", start);
     if !is_valid {
-        return Err("Compression proof verification failed".into());
+        return Err(anyhow::anyhow!("Compression proof verification failed"));
     }
     tracing::info!("Phase 2 proof verified successfully");
 
@@ -196,12 +197,12 @@ pub fn run_phase3_snark(
     compression_vk: crate::CompressionVK,
     trusted_setup: &Option<PathBuf>,
     use_zk: bool,
-) -> Result<(crate::SnarkWrapperProof, crate::SnarkWrapperVK), Box<dyn std::error::Error>> {
+) -> anyhow::Result<(crate::SnarkWrapperProof, crate::SnarkWrapperVK)> {
     #[cfg(not(feature = "gpu"))]
     let (snark_proof, snark_vk) = {
         tracing::info!("=== Phase 3 - load CRS: starting...");
         let start = Instant::now();
-        let crs_mons = load_crs(trusted_setup);
+        let crs_mons = load_crs(trusted_setup).context("crs")?;
         print_elapsed("Phase 3 - load CRS", start);
 
         let bellman_worker = BellmanWorker::new();
@@ -261,7 +262,7 @@ pub fn run_phase3_snark(
     let is_valid = crate::verify_snark_wrapper_proof(&snark_proof, &snark_vk);
     print_elapsed("Phase 3 - verify", start);
     if !is_valid {
-        return Err("SNARK wrapper proof verification failed".into());
+        return Err(anyhow::anyhow!("SNARK wrapper proof verification failed"));
     }
     tracing::info!("Phase 3 proof verified successfully");
 

--- a/wrapper/src/interface/utils.rs
+++ b/wrapper/src/interface/utils.rs
@@ -1,4 +1,5 @@
 use boojum::worker::Worker as BoojumWorker;
+use execution_utils::unrolled::UnrolledProgramProof;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -7,9 +8,9 @@ use bellman::kate_commitment::{Crs, CrsForMonomialForm};
 #[cfg(not(feature = "gpu"))]
 use bellman::worker::Worker as BellmanWorker;
 
-use crate::circuits::BinaryCommitment;
 #[cfg(not(feature = "gpu"))]
 use crate::{Bn256, L1_VERIFIER_DOMAIN_SIZE_LOG, get_trusted_setup};
+use crate::{circuits::BinaryCommitment, deserialize_from_file};
 
 // ==============================================================================
 // Local Execution Helpers
@@ -60,6 +61,12 @@ pub(super) fn load_binary_commitment(
             Ok(BinaryCommitment::from_default_binary())
         }
     }
+}
+
+/// Loads and deserialized the proof from file.
+pub fn load_proof(proof_path: &Path) -> UnrolledProgramProof {
+    tracing::info!("Loading FRI proof from {}", proof_path.display());
+    deserialize_from_file(proof_path.to_str().unwrap())
 }
 
 pub(super) fn ensure_output_dir(path: &Path) -> Result<(), Box<dyn std::error::Error>> {

--- a/wrapper/src/interface/utils.rs
+++ b/wrapper/src/interface/utils.rs
@@ -1,0 +1,92 @@
+use boojum::worker::Worker as BoojumWorker;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+#[cfg(not(feature = "gpu"))]
+use bellman::kate_commitment::{Crs, CrsForMonomialForm};
+#[cfg(not(feature = "gpu"))]
+use bellman::worker::Worker as BellmanWorker;
+
+use crate::circuits::BinaryCommitment;
+#[cfg(not(feature = "gpu"))]
+use crate::{Bn256, L1_VERIFIER_DOMAIN_SIZE_LOG, get_trusted_setup};
+
+// ==============================================================================
+// Local Execution Helpers
+// ==============================================================================
+//
+// The interface commands mostly orchestrate already-existing proving APIs.
+// These helpers keep the orchestration code focused on the pipeline itself:
+// worker selection, filesystem setup, shared timing logs, and loading optional
+// assets that are reused across multiple commands.
+
+pub(super) fn create_boojum_worker(threads: Option<usize>) -> BoojumWorker {
+    match threads {
+        Some(n) => {
+            tracing::info!("Using {n} worker threads");
+            BoojumWorker::new_with_num_threads(n)
+        }
+        None => BoojumWorker::new(),
+    }
+}
+
+/// Emits a consistent timing line after a named step completes.
+pub(super) fn print_elapsed(label: &str, start: Instant) {
+    tracing::info!(
+        "=== {label}: completed in {:.1}s",
+        start.elapsed().as_secs_f64()
+    );
+}
+
+/// Loads the recursion verifier binary when the caller overrides the defaults.
+///
+/// The pipeline always needs a `BinaryCommitment`, but CLI callers are allowed
+/// to either provide both binary artifacts or rely on the built-in verifier.
+pub(super) fn load_binary_commitment(
+    bin: &Option<PathBuf>,
+    text: &Option<PathBuf>,
+) -> Result<BinaryCommitment, Box<dyn std::error::Error>> {
+    match (bin, text) {
+        (Some(bin_path), Some(text_path)) => {
+            tracing::info!("Loading binary from {}", bin_path.display());
+            let binary = std::fs::read(bin_path)
+                .map_err(|e| format!("Failed to read .bin file {}: {e}", bin_path.display()))?;
+            let text_data = std::fs::read(text_path)
+                .map_err(|e| format!("Failed to read .text file {}: {e}", text_path.display()))?;
+            Ok(BinaryCommitment::from_binary(&binary, &text_data))
+        }
+        _ => {
+            tracing::info!("Using default recursion verifier binary");
+            Ok(BinaryCommitment::from_default_binary())
+        }
+    }
+}
+
+pub(super) fn ensure_output_dir(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::create_dir_all(path)
+        .map_err(|e| format!("Failed to create output directory {}: {e}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(feature = "gpu"))]
+pub(super) fn load_crs(trusted_setup: &Option<PathBuf>) -> Crs<Bn256, CrsForMonomialForm> {
+    match trusted_setup {
+        Some(path) => {
+            tracing::info!("Loading trusted setup from {}", path.display());
+            get_trusted_setup(&path.to_string_lossy().to_string())
+        }
+        None => {
+            tracing::info!(
+                "WARNING: Using fake crs_42 trusted setup (testing only, NOT for production!)"
+            );
+            Crs::<Bn256, CrsForMonomialForm>::crs_42(
+                1 << L1_VERIFIER_DOMAIN_SIZE_LOG,
+                &BellmanWorker::new(),
+            )
+        }
+    }
+}
+
+pub(super) fn output_path(dir: &Path, filename: &str) -> String {
+    dir.join(filename).to_string_lossy().to_string()
+}

--- a/wrapper/src/interface/utils.rs
+++ b/wrapper/src/interface/utils.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use boojum::worker::Worker as BoojumWorker;
 use execution_utils::unrolled::UnrolledProgramProof;
 use std::path::{Path, PathBuf};
@@ -46,14 +47,16 @@ pub(super) fn print_elapsed(label: &str, start: Instant) {
 pub(super) fn load_binary_commitment(
     bin: &Option<PathBuf>,
     text: &Option<PathBuf>,
-) -> Result<BinaryCommitment, Box<dyn std::error::Error>> {
+) -> anyhow::Result<BinaryCommitment> {
     match (bin, text) {
         (Some(bin_path), Some(text_path)) => {
             tracing::info!("Loading binary from {}", bin_path.display());
-            let binary = std::fs::read(bin_path)
-                .map_err(|e| format!("Failed to read .bin file {}: {e}", bin_path.display()))?;
-            let text_data = std::fs::read(text_path)
-                .map_err(|e| format!("Failed to read .text file {}: {e}", text_path.display()))?;
+            let binary = std::fs::read(bin_path).map_err(|e| {
+                anyhow::anyhow!("Failed to read .bin file {}: {e}", bin_path.display())
+            })?;
+            let text_data = std::fs::read(text_path).map_err(|e| {
+                anyhow::anyhow!("Failed to read .text file {}: {e}", text_path.display())
+            })?;
             Ok(BinaryCommitment::from_binary(&binary, &text_data))
         }
         _ => {
@@ -63,33 +66,36 @@ pub(super) fn load_binary_commitment(
     }
 }
 
-/// Loads and deserialized the proof from file.
-pub fn load_proof(proof_path: &Path) -> UnrolledProgramProof {
+/// Loads and deserializes the proof from file.
+pub fn load_proof(proof_path: &Path) -> anyhow::Result<UnrolledProgramProof> {
     tracing::info!("Loading FRI proof from {}", proof_path.display());
-    deserialize_from_file(proof_path.to_str().unwrap())
+    deserialize_from_file(proof_path.to_str().expect("Non-unicode file path"))
 }
 
-pub(super) fn ensure_output_dir(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    std::fs::create_dir_all(path)
-        .map_err(|e| format!("Failed to create output directory {}: {e}", path.display()))?;
+pub(super) fn ensure_output_dir(path: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(path).map_err(|e| {
+        anyhow::anyhow!("Failed to create output directory {}: {e}", path.display())
+    })?;
     Ok(())
 }
 
 #[cfg(not(feature = "gpu"))]
-pub(super) fn load_crs(trusted_setup: &Option<PathBuf>) -> Crs<Bn256, CrsForMonomialForm> {
+pub(super) fn load_crs(
+    trusted_setup: &Option<PathBuf>,
+) -> anyhow::Result<Crs<Bn256, CrsForMonomialForm>> {
     match trusted_setup {
         Some(path) => {
             tracing::info!("Loading trusted setup from {}", path.display());
-            get_trusted_setup(&path.to_string_lossy().to_string())
+            get_trusted_setup(&path.to_string_lossy().to_string()).context("Trusted setup")
         }
         None => {
             tracing::info!(
                 "WARNING: Using fake crs_42 trusted setup (testing only, NOT for production!)"
             );
-            Crs::<Bn256, CrsForMonomialForm>::crs_42(
+            Ok(Crs::<Bn256, CrsForMonomialForm>::crs_42(
                 1 << L1_VERIFIER_DOMAIN_SIZE_LOG,
                 &BellmanWorker::new(),
-            )
+            ))
         }
     }
 }

--- a/wrapper/src/interface/utils.rs
+++ b/wrapper/src/interface/utils.rs
@@ -13,15 +13,6 @@ use bellman::worker::Worker as BellmanWorker;
 use crate::{Bn256, L1_VERIFIER_DOMAIN_SIZE_LOG, get_trusted_setup};
 use crate::{circuits::BinaryCommitment, deserialize_from_file};
 
-// ==============================================================================
-// Local Execution Helpers
-// ==============================================================================
-//
-// The interface commands mostly orchestrate already-existing proving APIs.
-// These helpers keep the orchestration code focused on the pipeline itself:
-// worker selection, filesystem setup, shared timing logs, and loading optional
-// assets that are reused across multiple commands.
-
 pub(super) fn create_boojum_worker(threads: Option<usize>) -> BoojumWorker {
     match threads {
         Some(n) => {

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod circuits;
 mod inner_verifiers;
+pub mod interface;
 pub mod transcript;
 pub mod wrapper_utils;
 
@@ -411,7 +412,7 @@ pub fn prove_snark_wrapper(
     wrapper_circuit.synthesize(&mut assembly).unwrap();
 
     if use_zk {
-        println!("using zk (padding) proving");
+        tracing::info!("using zk (padding) proving");
         const NUM_PADDING_TERMS: usize = 2 + 2 + 2; // worst case witness polys are opened at 2 points, plus there are
         // indirect openings of grand product for permutation and for lookup
         let mut rng = rand::rngs::OsRng;
@@ -421,7 +422,7 @@ pub fn prove_snark_wrapper(
             &mut rng,
         );
     } else {
-        println!("using non-zk (no padding) proving");
+        tracing::info!("using non-zk (no padding) proving");
         assembly.finalize_to_size_log_2(L1_VERIFIER_DOMAIN_SIZE_LOG);
     }
 
@@ -538,11 +539,12 @@ pub fn prove_risc_wrapper_with_snark(
     use_zk: bool,
 ) -> Result<(SnarkWrapperProof, SnarkWrapperVK), Box<dyn std::error::Error>> {
     let worker = boojum::worker::Worker::new();
-    println!("=== Phase 2: Creating compression proof");
+    tracing::info!("=== Phase 2: Creating compression proof");
 
     #[cfg(feature = "gpu")]
     let (compression_proof, compression_vk) = {
-        let config = shivini::ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+        let config =
+            shivini::ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
         let _prover_context = shivini::ProverContext::create_with_config(config).unwrap();
 
         let (setup, compression_vk, finalization) =
@@ -589,11 +591,11 @@ pub fn prove_risc_wrapper_with_snark(
         return Err("Compression proof is not valid".into());
     }
 
-    println!("=== Phase 3: Creating SNARK proof");
+    tracing::info!("=== Phase 3: Creating SNARK proof");
 
     #[cfg(feature = "gpu")]
     {
-        println!("Using GPU for SNARK proof generation");
+        tracing::info!("Using GPU for SNARK proof generation");
         let crs_file =
             trusted_setup_file.expect("Trusted setup must be set for GPU (and it must be compat");
 
@@ -601,7 +603,7 @@ pub fn prove_risc_wrapper_with_snark(
 
         let (setup_data, vk) = match precomputations {
             Some((setup_data, vk)) => {
-                println!("Using provided precomputations");
+                tracing::info!("Using provided precomputations");
                 (setup_data, vk)
             }
             None => {
@@ -659,7 +661,7 @@ pub fn prove_risc_wrapper_with_snark(
 // pub fn prove_fri_risc_wrapper(
 //     program_proof: ProgramProof,
 // ) -> Result<(RiscWrapperProof, RiscWrapperVK), Box<dyn std::error::Error>> {
-//     println!("=== Phase 1: Creating the Risc wrapper proof");
+//     tracing::info!("=== Phase 1: Creating the Risc wrapper proof");
 
 //     let worker = boojum::worker::Worker::new();
 
@@ -828,7 +830,7 @@ pub fn prove_risc_wrapper_with_snark(
 // ) -> Result<H256, Box<dyn std::error::Error>> {
 //     let boojum_worker = boojum::worker::Worker::new();
 
-//     println!("=== Phase 1: Creating the Risc wrapper key");
+//     tracing::info!("=== Phase 1: Creating the Risc wrapper key");
 
 //     let risc_wrapper_vk = generate_risk_wrapper_vk(
 //         input_binary,
@@ -837,15 +839,15 @@ pub fn prove_risc_wrapper_with_snark(
 //         &boojum_worker,
 //     )?;
 
-//     println!("=== Phase 2: Creating the Compression key");
+//     tracing::info!("=== Phase 2: Creating the Compression key");
 //     let (_, _, _, compression_vk, _, _, _) =
 //         get_compression_setup(risc_wrapper_vk.clone(), &boojum_worker);
 
-//     println!("=== Phase 3: Creating the SNARK key");
+//     tracing::info!("=== Phase 3: Creating the SNARK key");
 
 //     #[cfg(feature = "gpu")]
 //     let snark_wrapper_vk = {
-//         println!("Using GPU for SNARK key generation");
+//         tracing::info!("Using GPU for SNARK key generation");
 //         let crs_file =
 //             trusted_setup_file.expect("Trusted setup must be set for GPU (and it must be compat");
 //         let (preprocessing, snark_wrapper_vk) =
@@ -880,7 +882,7 @@ pub fn prove_risc_wrapper_with_snark(
 //     );
 
 //     let verification_key = calculate_verification_key_hash(snark_wrapper_vk);
-//     println!("VK key hash: {verification_key:?}");
+//     tracing::info!("VK key hash: {verification_key:?}");
 
 //     Ok(verification_key)
 // }
@@ -888,5 +890,5 @@ pub fn prove_risc_wrapper_with_snark(
 pub fn verification_hash(vk_path: String) {
     let vk = deserialize_from_file(&vk_path);
     let vk_hash = calculate_verification_key_hash(vk);
-    println!("VK hash: {vk_hash:?}");
+    tracing::info!("VK hash: {vk_hash:?}");
 }

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -49,6 +49,8 @@ use std::alloc::Global;
 use std::path::Path;
 use wrapper_utils::verifier_traits::CircuitBlake2sForEverythingVerifier;
 
+use anyhow::Context as _;
+
 pub type GL = boojum::field::goldilocks::GoldilocksField;
 pub type GLExt2 = boojum::field::goldilocks::GoldilocksExt2;
 pub type RiscLeafInclusionVerifier = CircuitBlake2sForEverythingVerifier<GL>;
@@ -509,21 +511,29 @@ pub fn calculate_verification_key_hash(verification_key: SnarkWrapperVK) -> H256
 }
 
 /// Uploads trusted setup file to the RAM
-pub fn get_trusted_setup(crs_file_str: &String) -> Crs<Bn256, CrsForMonomialForm> {
+pub fn get_trusted_setup(crs_file_str: &String) -> anyhow::Result<Crs<Bn256, CrsForMonomialForm>> {
     let crs_file_path = std::path::Path::new(crs_file_str);
     let crs_file = std::fs::File::open(&crs_file_path)
-        .expect(format!("Trying to open CRS FILE: {:?}", crs_file_path).as_str());
-    Crs::read(&crs_file).expect(format!("Trying to read CRS FILE: {:?}", crs_file_path).as_str())
+        .with_context(|| format!("Can't open CRS FILE: {:?}", crs_file_path))?;
+    Crs::read(&crs_file).with_context(|| format!("Can't read CRS FILE: {:?}", crs_file_path))
 }
 
-pub fn serialize_to_file<T: serde::ser::Serialize>(content: &T, filename: &str) {
-    let src = std::fs::File::create(filename).expect(filename);
-    serde_json::to_writer_pretty(src, content).expect(filename);
+pub fn serialize_to_file<T: serde::ser::Serialize>(
+    content: &T,
+    filename: &str,
+) -> anyhow::Result<()> {
+    let src =
+        std::fs::File::create(filename).with_context(|| format!("Can't create file {filename}"))?;
+    serde_json::to_writer_pretty(src, content)
+        .with_context(|| format!("Can't serialize {filename}"))?;
+    Ok(())
 }
 
-pub fn deserialize_from_file<T: serde::de::DeserializeOwned>(filename: &str) -> T {
-    let src = std::fs::File::open(filename).expect(filename);
-    serde_json::from_reader(src).expect(filename)
+pub fn deserialize_from_file<T: serde::de::DeserializeOwned>(filename: &str) -> anyhow::Result<T> {
+    let src =
+        std::fs::File::open(filename).with_context(|| format!("Can't open file {filename}"))?;
+    serde_json::from_reader(src)
+        .with_context(|| format!("Can't deserialize the contents of file {filename}"))
 }
 
 pub fn prove_risc_wrapper_with_snark(
@@ -537,7 +547,7 @@ pub fn prove_risc_wrapper_with_snark(
     // TODO!: Remove by end of Q4 2025.
     // Currently in place to allow a easy revert in case ZK proving causes issues.
     use_zk: bool,
-) -> Result<(SnarkWrapperProof, SnarkWrapperVK), Box<dyn std::error::Error>> {
+) -> anyhow::Result<(SnarkWrapperProof, SnarkWrapperVK)> {
     let worker = boojum::worker::Worker::new();
     tracing::info!("=== Phase 2: Creating compression proof");
 
@@ -588,7 +598,7 @@ pub fn prove_risc_wrapper_with_snark(
     let is_valid = verify_compression_proof(&compression_proof, &compression_vk);
 
     if !is_valid {
-        return Err("Compression proof is not valid".into());
+        return Err(anyhow::anyhow!("Compression proof is not valid"));
     }
 
     tracing::info!("=== Phase 3: Creating SNARK proof");
@@ -626,7 +636,7 @@ pub fn prove_risc_wrapper_with_snark(
     #[cfg(not(feature = "gpu"))]
     {
         let crs_mons = match trusted_setup_file {
-            Some(ref crs_file_str) => get_trusted_setup(crs_file_str),
+            Some(ref crs_file_str) => get_trusted_setup(crs_file_str)?,
             None => Crs::<Bn256, CrsForMonomialForm>::crs_42(
                 1 << L1_VERIFIER_DOMAIN_SIZE_LOG,
                 &BellmanWorker::new(),
@@ -651,7 +661,7 @@ pub fn prove_risc_wrapper_with_snark(
             let is_valid = verify_snark_wrapper_proof(&snark_wrapper_proof, &snark_wrapper_vk);
 
             if !is_valid {
-                return Err("Snark wrapper proof is not valid".into());
+                return Err(anyhow::anyhow!("Snark wrapper proof is not valid"));
             }
             Ok((snark_wrapper_proof, snark_wrapper_vk))
         }
@@ -887,8 +897,9 @@ pub fn prove_risc_wrapper_with_snark(
 //     Ok(verification_key)
 // }
 
-pub fn verification_hash(vk_path: String) {
-    let vk = deserialize_from_file(&vk_path);
+pub fn verification_hash(vk_path: String) -> anyhow::Result<()> {
+    let vk = deserialize_from_file(&vk_path).context("Can't deserialize VK")?;
     let vk_hash = calculate_verification_key_hash(vk);
     tracing::info!("VK hash: {vk_hash:?}");
+    Ok(())
 }

--- a/wrapper/src/main.rs
+++ b/wrapper/src/main.rs
@@ -1,21 +1,12 @@
 #![feature(allocator_api)]
 
-use boojum::worker::Worker as BoojumWorker;
 use clap::{Parser, Subcommand, ValueEnum};
-use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::error::Error;
+use std::path::PathBuf;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
 
-#[cfg(not(feature = "gpu"))]
-use bellman::kate_commitment::{Crs, CrsForMonomialForm};
-#[cfg(not(feature = "gpu"))]
-use bellman::worker::Worker as BellmanWorker;
-
-use zkos_wrapper::{
-    calculate_verification_key_hash, deserialize_from_file, serialize_to_file,
-    circuits::{BinaryCommitment, RiscWrapperWitness},
-};
-#[cfg(not(feature = "gpu"))]
-use zkos_wrapper::{Bn256, L1_VERIFIER_DOMAIN_SIZE_LOG, get_trusted_setup};
+use zkos_wrapper::interface;
 
 #[derive(Parser)]
 #[command(
@@ -171,620 +162,33 @@ enum VerifyStage {
     Snark,
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn create_boojum_worker(threads: Option<usize>) -> BoojumWorker {
-    match threads {
-        Some(n) => {
-            println!("Using {n} worker threads");
-            BoojumWorker::new_with_num_threads(n)
-        }
-        None => BoojumWorker::new(),
-    }
-}
-
-/// Prints a timing message for a named phase. Call with the label and start instant
-/// after the work is done.
-fn print_elapsed(label: &str, start: Instant) {
-    println!("=== {label}: completed in {:.1}s", start.elapsed().as_secs_f64());
-}
-
-fn load_binary_commitment(
-    bin: &Option<PathBuf>,
-    text: &Option<PathBuf>,
-) -> Result<BinaryCommitment, Box<dyn std::error::Error>> {
-    match (bin, text) {
-        (Some(bin_path), Some(text_path)) => {
-            println!("Loading binary from {}", bin_path.display());
-            let binary = std::fs::read(bin_path)
-                .map_err(|e| format!("Failed to read .bin file {}: {e}", bin_path.display()))?;
-            let text_data = std::fs::read(text_path)
-                .map_err(|e| format!("Failed to read .text file {}: {e}", text_path.display()))?;
-            Ok(BinaryCommitment::from_binary(&binary, &text_data))
-        }
-        _ => {
-            println!("Using default recursion verifier binary");
-            Ok(BinaryCommitment::from_default_binary())
+impl From<VerifyStage> for zkos_wrapper::interface::VerifyStage {
+    fn from(this: VerifyStage) -> Self {
+        match this {
+            VerifyStage::RiscWrapper => Self::RiscWrapper,
+            VerifyStage::Compression => Self::Compression,
+            VerifyStage::Snark => Self::Snark,
         }
     }
 }
 
-fn ensure_output_dir(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    std::fs::create_dir_all(path)
-        .map_err(|e| format!("Failed to create output directory {}: {e}", path.display()))?;
-    Ok(())
-}
+// `INFO` logs are enabled by default, but `RUST_LOG` overrides are supported as well.
+fn init_tracing() -> Result<(), Box<dyn Error>> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
 
-#[cfg(not(feature = "gpu"))]
-fn load_crs(trusted_setup: &Option<PathBuf>) -> Crs<Bn256, CrsForMonomialForm> {
-    match trusted_setup {
-        Some(path) => {
-            println!("Loading trusted setup from {}", path.display());
-            get_trusted_setup(&path.to_string_lossy().to_string())
-        }
-        None => {
-            println!(
-                "WARNING: Using fake crs_42 trusted setup (testing only, NOT for production!)"
-            );
-            Crs::<Bn256, CrsForMonomialForm>::crs_42(
-                1 << L1_VERIFIER_DOMAIN_SIZE_LOG,
-                &BellmanWorker::new(),
-            )
-        }
-    }
-}
-
-fn output_path(dir: &Path, filename: &str) -> String {
-    dir.join(filename).to_string_lossy().to_string()
-}
-
-// ---------------------------------------------------------------------------
-// Phase implementations
-// ---------------------------------------------------------------------------
-
-fn run_phase1_risc_wrapper(
-    proof_path: &Path,
-    bin: &Option<PathBuf>,
-    text: &Option<PathBuf>,
-    worker: &BoojumWorker,
-) -> Result<
-    (zkos_wrapper::RiscWrapperProof, zkos_wrapper::RiscWrapperVK),
-    Box<dyn std::error::Error>,
-> {
-    println!("=== Phase 1 - binary commitment: starting...");
-    let start = Instant::now();
-    let binary_commitment = load_binary_commitment(bin, text)?;
-    print_elapsed("Phase 1 - binary commitment", start);
-
-    println!("Loading FRI proof from {}", proof_path.display());
-    let program_proof: execution_utils::unrolled::UnrolledProgramProof =
-        deserialize_from_file(proof_path.to_str().unwrap());
-
-    println!("=== Phase 1 - witness generation: starting...");
-    let start = Instant::now();
-    let risc_wrapper_witness =
-        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment);
-    print_elapsed("Phase 1 - witness generation", start);
-
-    #[cfg(not(feature = "gpu"))]
-    let (risc_wrapper_proof, risc_wrapper_vk) = {
-        println!("=== Phase 1 - setup (CPU): starting...");
-        let start = Instant::now();
-        let (finalization_hint, setup_base, setup, risc_wrapper_vk, setup_tree, vars_hint, witness_hints) =
-            zkos_wrapper::get_risc_wrapper_setup(worker, binary_commitment.clone());
-        print_elapsed("Phase 1 - setup (CPU)", start);
-
-        println!("=== Phase 1 - prove (CPU): starting...");
-        let start = Instant::now();
-        let risc_wrapper_proof = zkos_wrapper::prove_risc_wrapper(
-            risc_wrapper_witness,
-            &finalization_hint,
-            &setup_base,
-            &setup,
-            &risc_wrapper_vk,
-            &setup_tree,
-            &vars_hint,
-            &witness_hints,
-            worker,
-            binary_commitment,
-        );
-        print_elapsed("Phase 1 - prove (CPU)", start);
-
-        (risc_wrapper_proof, risc_wrapper_vk)
-    };
-
-    #[cfg(feature = "gpu")]
-    let (risc_wrapper_proof, risc_wrapper_vk) = {
-        println!("=== Phase 1 - setup (GPU): starting...");
-        let start = Instant::now();
-        let (gpu_setup, gpu_vk, finalization_hint) =
-            zkos_wrapper::gpu::risc_wrapper::get_risc_wrapper_setup(worker, binary_commitment.clone());
-        print_elapsed("Phase 1 - setup (GPU)", start);
-
-        println!("=== Phase 1 - prove (GPU): starting...");
-        let start = Instant::now();
-        let risc_wrapper_proof = zkos_wrapper::gpu::risc_wrapper::prove_risc_wrapper(
-            risc_wrapper_witness,
-            &finalization_hint,
-            &gpu_setup,
-            &gpu_vk,
-            worker,
-            binary_commitment,
-        );
-        print_elapsed("Phase 1 - prove (GPU)", start);
-
-        (risc_wrapper_proof, gpu_vk)
-    };
-
-    println!("=== Phase 1 - verify: starting...");
-    let start = Instant::now();
-    let is_valid = zkos_wrapper::verify_risc_wrapper_proof(&risc_wrapper_proof, &risc_wrapper_vk);
-    print_elapsed("Phase 1 - verify", start);
-    if !is_valid {
-        return Err("RISC wrapper proof verification failed".into());
-    }
-    println!("Phase 1 proof verified successfully");
-
-    Ok((risc_wrapper_proof, risc_wrapper_vk))
-}
-
-fn run_phase2_compression(
-    risc_wrapper_proof: zkos_wrapper::RiscWrapperProof,
-    risc_wrapper_vk: zkos_wrapper::RiscWrapperVK,
-    worker: &BoojumWorker,
-) -> Result<
-    (zkos_wrapper::CompressionProof, zkos_wrapper::CompressionVK),
-    Box<dyn std::error::Error>,
-> {
-    #[cfg(not(feature = "gpu"))]
-    let (compression_proof, compression_vk) = {
-        println!("=== Phase 2 - setup (CPU): starting...");
-        let start = Instant::now();
-        let (finalization_hint, setup_base, setup, compression_vk, setup_tree, vars_hint, witness_hints) =
-            zkos_wrapper::get_compression_setup(risc_wrapper_vk.clone(), worker);
-        print_elapsed("Phase 2 - setup (CPU)", start);
-
-        println!("=== Phase 2 - prove (CPU): starting...");
-        let start = Instant::now();
-        let compression_proof = zkos_wrapper::prove_compression(
-            risc_wrapper_proof,
-            risc_wrapper_vk,
-            &finalization_hint,
-            &setup_base,
-            &setup,
-            &compression_vk,
-            &setup_tree,
-            &vars_hint,
-            &witness_hints,
-            worker,
-        );
-        print_elapsed("Phase 2 - prove (CPU)", start);
-
-        (compression_proof, compression_vk)
-    };
-
-    #[cfg(feature = "gpu")]
-    let (compression_proof, compression_vk) = {
-        let config = shivini::ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
-        let _prover_context = shivini::ProverContext::create_with_config(config).unwrap();
-
-        println!("=== Phase 2 - setup (GPU): starting...");
-        let start = Instant::now();
-        let (gpu_setup, gpu_vk, finalization_hint) =
-            zkos_wrapper::gpu::compression::get_compression_setup(worker, risc_wrapper_vk.clone());
-        print_elapsed("Phase 2 - setup (GPU)", start);
-
-        println!("=== Phase 2 - prove (GPU): starting...");
-        let start = Instant::now();
-        let compression_proof = zkos_wrapper::gpu::compression::prove_compression(
-            risc_wrapper_proof,
-            risc_wrapper_vk,
-            &finalization_hint,
-            &gpu_setup,
-            &gpu_vk,
-            worker,
-        );
-        print_elapsed("Phase 2 - prove (GPU)", start);
-
-        (compression_proof, gpu_vk)
-    };
-
-    println!("=== Phase 2 - verify: starting...");
-    let start = Instant::now();
-    let is_valid = zkos_wrapper::verify_compression_proof(&compression_proof, &compression_vk);
-    print_elapsed("Phase 2 - verify", start);
-    if !is_valid {
-        return Err("Compression proof verification failed".into());
-    }
-    println!("Phase 2 proof verified successfully");
-
-    Ok((compression_proof, compression_vk))
-}
-
-fn run_phase3_snark(
-    compression_proof: zkos_wrapper::CompressionProof,
-    compression_vk: zkos_wrapper::CompressionVK,
-    trusted_setup: &Option<PathBuf>,
-    use_zk: bool,
-) -> Result<
-    (
-        zkos_wrapper::SnarkWrapperProof,
-        zkos_wrapper::SnarkWrapperVK,
-    ),
-    Box<dyn std::error::Error>,
-> {
-    #[cfg(not(feature = "gpu"))]
-    let (snark_proof, snark_vk) = {
-        println!("=== Phase 3 - load CRS: starting...");
-        let start = Instant::now();
-        let crs_mons = load_crs(trusted_setup);
-        print_elapsed("Phase 3 - load CRS", start);
-
-        let bellman_worker = BellmanWorker::new();
-
-        println!("=== Phase 3 - setup (CPU): starting...");
-        let start = Instant::now();
-        let (snark_setup, snark_vk) =
-            zkos_wrapper::get_snark_wrapper_setup(compression_vk.clone(), &crs_mons, &bellman_worker);
-        print_elapsed("Phase 3 - setup (CPU)", start);
-
-        println!("=== Phase 3 - prove (CPU): starting...");
-        let start = Instant::now();
-        let snark_proof = zkos_wrapper::prove_snark_wrapper(
-            compression_proof,
-            compression_vk,
-            &snark_setup,
-            &crs_mons,
-            &bellman_worker,
-            use_zk,
-        );
-        print_elapsed("Phase 3 - prove (CPU)", start);
-
-        (snark_proof, snark_vk)
-    };
-
-    #[cfg(feature = "gpu")]
-    let (snark_proof, snark_vk) = {
-        let crs_file = trusted_setup
-            .as_ref()
-            .expect("GPU SNARK proving requires a trusted setup file path (--trusted-setup)")
-            .to_string_lossy()
-            .to_string();
-
-        println!("=== Phase 3 - setup (GPU): starting...");
-        let start = Instant::now();
-        let (precomputation, snark_vk) =
-            zkos_wrapper::gpu::snark::gpu_create_snark_setup_data(&compression_vk, &crs_file);
-        print_elapsed("Phase 3 - setup (GPU)", start);
-
-        println!("=== Phase 3 - prove (GPU): starting...");
-        let start = Instant::now();
-        let snark_proof = zkos_wrapper::gpu::snark::gpu_snark_prove(
-            &precomputation,
-            &snark_vk,
-            compression_proof,
-            compression_vk,
-            &crs_file,
-            use_zk,
-        );
-        print_elapsed("Phase 3 - prove (GPU)", start);
-
-        (snark_proof, snark_vk)
-    };
-
-    println!("=== Phase 3 - verify: starting...");
-    let start = Instant::now();
-    let is_valid = zkos_wrapper::verify_snark_wrapper_proof(&snark_proof, &snark_vk);
-    print_elapsed("Phase 3 - verify", start);
-    if !is_valid {
-        return Err("SNARK wrapper proof verification failed".into());
-    }
-    println!("Phase 3 proof verified successfully");
-
-    Ok((snark_proof, snark_vk))
-}
-
-// ---------------------------------------------------------------------------
-// Subcommand handlers
-// ---------------------------------------------------------------------------
-
-fn cmd_prove_all(
-    proof: PathBuf,
-    bin: Option<PathBuf>,
-    text: Option<PathBuf>,
-    output_dir: PathBuf,
-    trusted_setup: Option<PathBuf>,
-    use_zk: bool,
-    save_intermediates: bool,
-    threads: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    ensure_output_dir(&output_dir)?;
-    let total_start = Instant::now();
-    let worker = create_boojum_worker(threads);
-
-    // Phase 1
-    let (risc_wrapper_proof, risc_wrapper_vk) =
-        run_phase1_risc_wrapper(&proof, &bin, &text, &worker)?;
-
-    if save_intermediates {
-        serialize_to_file(
-            &risc_wrapper_proof,
-            &output_path(&output_dir, "risc_wrapper_proof.json"),
-        );
-        serialize_to_file(
-            &risc_wrapper_vk,
-            &output_path(&output_dir, "risc_wrapper_vk.json"),
-        );
-        println!("Saved intermediate Phase 1 outputs");
-    }
-
-    // Phase 2
-    let (compression_proof, compression_vk) =
-        run_phase2_compression(risc_wrapper_proof, risc_wrapper_vk, &worker)?;
-
-    if save_intermediates {
-        serialize_to_file(
-            &compression_proof,
-            &output_path(&output_dir, "compression_proof.json"),
-        );
-        serialize_to_file(
-            &compression_vk,
-            &output_path(&output_dir, "compression_vk.json"),
-        );
-        println!("Saved intermediate Phase 2 outputs");
-    }
-
-    // Phase 3
-    let (snark_proof, snark_vk) =
-        run_phase3_snark(compression_proof, compression_vk, &trusted_setup, use_zk)?;
-
-    serialize_to_file(&snark_proof, &output_path(&output_dir, "snark_proof.json"));
-    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
-
-    let vk_hash = calculate_verification_key_hash(snark_vk);
-    println!("SNARK VK hash: {vk_hash:?}");
-
-    let total_elapsed = total_start.elapsed();
-    println!(
-        "=== Total pipeline time: {:.1}s",
-        total_elapsed.as_secs_f64()
-    );
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .try_init()
+        .map_err(|error| format!("Failed to initialize tracing subscriber: {error}"))?;
 
     Ok(())
 }
 
-fn cmd_prove_risc_wrapper(
-    proof: PathBuf,
-    bin: Option<PathBuf>,
-    text: Option<PathBuf>,
-    output_dir: PathBuf,
-    threads: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    ensure_output_dir(&output_dir)?;
-    let worker = create_boojum_worker(threads);
+fn main() -> Result<(), Box<dyn Error>> {
+    init_tracing()?;
 
-    let (risc_wrapper_proof, risc_wrapper_vk) =
-        run_phase1_risc_wrapper(&proof, &bin, &text, &worker)?;
-
-    serialize_to_file(
-        &risc_wrapper_proof,
-        &output_path(&output_dir, "risc_wrapper_proof.json"),
-    );
-    serialize_to_file(
-        &risc_wrapper_vk,
-        &output_path(&output_dir, "risc_wrapper_vk.json"),
-    );
-
-    Ok(())
-}
-
-fn cmd_prove_compression(
-    risc_wrapper_proof_path: PathBuf,
-    risc_wrapper_vk_path: PathBuf,
-    output_dir: PathBuf,
-    threads: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    ensure_output_dir(&output_dir)?;
-    let worker = create_boojum_worker(threads);
-
-    println!(
-        "Loading RISC wrapper proof from {}",
-        risc_wrapper_proof_path.display()
-    );
-    let risc_wrapper_proof = deserialize_from_file(risc_wrapper_proof_path.to_str().unwrap());
-    println!(
-        "Loading RISC wrapper VK from {}",
-        risc_wrapper_vk_path.display()
-    );
-    let risc_wrapper_vk = deserialize_from_file(risc_wrapper_vk_path.to_str().unwrap());
-
-    let (compression_proof, compression_vk) =
-        run_phase2_compression(risc_wrapper_proof, risc_wrapper_vk, &worker)?;
-
-    serialize_to_file(
-        &compression_proof,
-        &output_path(&output_dir, "compression_proof.json"),
-    );
-    serialize_to_file(
-        &compression_vk,
-        &output_path(&output_dir, "compression_vk.json"),
-    );
-
-    Ok(())
-}
-
-fn cmd_prove_snark(
-    compression_proof_path: PathBuf,
-    compression_vk_path: PathBuf,
-    output_dir: PathBuf,
-    trusted_setup: Option<PathBuf>,
-    use_zk: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    ensure_output_dir(&output_dir)?;
-
-    println!(
-        "Loading compression proof from {}",
-        compression_proof_path.display()
-    );
-    let compression_proof = deserialize_from_file(compression_proof_path.to_str().unwrap());
-    println!(
-        "Loading compression VK from {}",
-        compression_vk_path.display()
-    );
-    let compression_vk = deserialize_from_file(compression_vk_path.to_str().unwrap());
-
-    let (snark_proof, snark_vk) =
-        run_phase3_snark(compression_proof, compression_vk, &trusted_setup, use_zk)?;
-
-    serialize_to_file(&snark_proof, &output_path(&output_dir, "snark_proof.json"));
-    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
-
-    let vk_hash = calculate_verification_key_hash(snark_vk);
-    println!("SNARK VK hash: {vk_hash:?}");
-
-    Ok(())
-}
-
-fn cmd_generate_vk(
-    output_dir: PathBuf,
-    bin: Option<PathBuf>,
-    text: Option<PathBuf>,
-    trusted_setup: Option<PathBuf>,
-    threads: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    ensure_output_dir(&output_dir)?;
-    let worker = create_boojum_worker(threads);
-
-    // Phase 1: RISC wrapper VK
-    println!("=== VK generation - binary commitment: starting...");
-    let start = Instant::now();
-    let binary_commitment = load_binary_commitment(&bin, &text)?;
-    print_elapsed("VK generation - binary commitment", start);
-
-    println!("=== VK generation - Phase 1 (RISC wrapper): starting...");
-    let start = Instant::now();
-    #[cfg(not(feature = "gpu"))]
-    let risc_wrapper_vk = {
-        let (_, _, _, risc_wrapper_vk, _, _, _) =
-            zkos_wrapper::get_risc_wrapper_setup(&worker, binary_commitment);
-        risc_wrapper_vk
-    };
-    #[cfg(feature = "gpu")]
-    let risc_wrapper_vk = {
-        let (_, gpu_vk, _) =
-            zkos_wrapper::gpu::risc_wrapper::get_risc_wrapper_setup(&worker, binary_commitment);
-        gpu_vk
-    };
-    print_elapsed("VK generation - Phase 1 (RISC wrapper)", start);
-    serialize_to_file(&risc_wrapper_vk, &output_path(&output_dir, "risc_wrapper_vk.json"));
-    println!("Saved risc_wrapper_vk.json");
-
-    // Phase 2: Compression VK
-    println!("=== VK generation - Phase 2 (compression): starting...");
-    let start = Instant::now();
-    #[cfg(not(feature = "gpu"))]
-    let compression_vk = {
-        let (_, _, _, compression_vk, _, _, _) =
-            zkos_wrapper::get_compression_setup(risc_wrapper_vk, &worker);
-        compression_vk
-    };
-    #[cfg(feature = "gpu")]
-    let compression_vk = {
-        let config = shivini::ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
-        let _prover_context = shivini::ProverContext::create_with_config(config).unwrap();
-
-        let (_, gpu_vk, _) =
-            zkos_wrapper::gpu::compression::get_compression_setup(&worker, risc_wrapper_vk);
-        gpu_vk
-    };
-    print_elapsed("VK generation - Phase 2 (compression)", start);
-    serialize_to_file(&compression_vk, &output_path(&output_dir, "compression_vk.json"));
-    println!("Saved compression_vk.json");
-
-    // Phase 3: SNARK VK
-    println!("=== VK generation - Phase 3 (SNARK): starting...");
-    let start = Instant::now();
-    #[cfg(not(feature = "gpu"))]
-    let snark_vk = {
-        let crs_mons = load_crs(&trusted_setup);
-        let bellman_worker = BellmanWorker::new();
-        let (_, snark_vk) =
-            zkos_wrapper::get_snark_wrapper_setup(compression_vk, &crs_mons, &bellman_worker);
-        snark_vk
-    };
-    #[cfg(feature = "gpu")]
-    let snark_vk = {
-        let crs_file = trusted_setup
-            .as_ref()
-            .expect("GPU VK generation requires a trusted setup file path (--trusted-setup)")
-            .to_string_lossy()
-            .to_string();
-        let (_, snark_vk) =
-            zkos_wrapper::gpu::snark::gpu_create_snark_setup_data(&compression_vk, &crs_file);
-        snark_vk
-    };
-    print_elapsed("VK generation - Phase 3 (SNARK)", start);
-    serialize_to_file(&snark_vk, &output_path(&output_dir, "snark_vk.json"));
-    println!("Saved snark_vk.json");
-
-    let vk_hash = calculate_verification_key_hash(snark_vk);
-    println!("SNARK VK hash: {vk_hash:?}");
-
-    Ok(())
-}
-
-fn cmd_vk_hash(vk_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Loading VK from {}", vk_path.display());
-    let vk = deserialize_from_file(vk_path.to_str().unwrap());
-    let vk_hash = calculate_verification_key_hash(vk);
-    println!("SNARK VK hash: {vk_hash:?}");
-    Ok(())
-}
-
-fn cmd_verify(
-    stage: VerifyStage,
-    proof_path: PathBuf,
-    vk_path: PathBuf,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let proof_str = proof_path.to_str().unwrap();
-    let vk_str = vk_path.to_str().unwrap();
-
-    let is_valid = match stage {
-        VerifyStage::RiscWrapper => {
-            println!("Verifying RISC wrapper proof...");
-            let proof = deserialize_from_file(proof_str);
-            let vk = deserialize_from_file(vk_str);
-            zkos_wrapper::verify_risc_wrapper_proof(&proof, &vk)
-        }
-        VerifyStage::Compression => {
-            println!("Verifying compression proof...");
-            let proof = deserialize_from_file(proof_str);
-            let vk = deserialize_from_file(vk_str);
-            zkos_wrapper::verify_compression_proof(&proof, &vk)
-        }
-        VerifyStage::Snark => {
-            println!("Verifying SNARK proof...");
-            let proof = deserialize_from_file(proof_str);
-            let vk = deserialize_from_file(vk_str);
-            zkos_wrapper::verify_snark_wrapper_proof(&proof, &vk)
-        }
-    };
-
-    if is_valid {
-        println!("Proof is VALID");
-        Ok(())
-    } else {
-        Err("Proof verification FAILED".into())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -796,7 +200,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             trusted_setup,
             use_zk,
             save_intermediates,
-        } => cmd_prove_all(
+        } => interface::cmd_prove_all(
             proof,
             bin,
             text,
@@ -812,13 +216,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             bin,
             text,
             output_dir,
-        } => cmd_prove_risc_wrapper(proof, bin, text, output_dir, cli.threads),
+        } => interface::cmd_prove_risc_wrapper(proof, bin, text, output_dir, cli.threads),
 
         Commands::ProveCompression {
             risc_wrapper_proof,
             risc_wrapper_vk,
             output_dir,
-        } => cmd_prove_compression(risc_wrapper_proof, risc_wrapper_vk, output_dir, cli.threads),
+        } => interface::cmd_prove_compression(
+            risc_wrapper_proof,
+            risc_wrapper_vk,
+            output_dir,
+            cli.threads,
+        ),
 
         Commands::ProveSnark {
             compression_proof,
@@ -826,7 +235,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_dir,
             trusted_setup,
             use_zk,
-        } => cmd_prove_snark(
+        } => interface::cmd_prove_snark(
             compression_proof,
             compression_vk,
             output_dir,
@@ -839,10 +248,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             bin,
             text,
             trusted_setup,
-        } => cmd_generate_vk(output_dir, bin, text, trusted_setup, cli.threads),
+        } => interface::cmd_generate_vk(output_dir, bin, text, trusted_setup, cli.threads),
 
-        Commands::VkHash { vk } => cmd_vk_hash(vk),
+        Commands::VkHash { vk } => interface::cmd_vk_hash(vk),
 
-        Commands::Verify { stage, proof, vk } => cmd_verify(stage, proof, vk),
+        Commands::Verify { stage, proof, vk } => interface::cmd_verify(stage.into(), proof, vk),
     }
 }

--- a/wrapper/src/main.rs
+++ b/wrapper/src/main.rs
@@ -1,7 +1,6 @@
 #![feature(allocator_api)]
 
 use clap::{Parser, Subcommand, ValueEnum};
-use std::error::Error;
 use std::path::PathBuf;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
@@ -173,7 +172,7 @@ impl From<VerifyStage> for zkos_wrapper::interface::VerifyStage {
 }
 
 // `INFO` logs are enabled by default, but `RUST_LOG` overrides are supported as well.
-fn init_tracing() -> Result<(), Box<dyn Error>> {
+fn init_tracing() -> anyhow::Result<()> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();
@@ -181,12 +180,12 @@ fn init_tracing() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(env_filter)
         .try_init()
-        .map_err(|error| format!("Failed to initialize tracing subscriber: {error}"))?;
+        .map_err(|error| anyhow::anyhow!("Failed to initialize tracing subscriber: {error}"))?;
 
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> anyhow::Result<()> {
     init_tracing()?;
 
     let cli = Cli::parse();

--- a/wrapper/src/tests/blake2s_tests.rs
+++ b/wrapper/src/tests/blake2s_tests.rs
@@ -175,7 +175,7 @@ fn test_blake2s_round_function() {
 //     // let worker = zkos_verifier_worker::Worker::new_with_num_threads(4);
 //     // let (mut _seed, pow_nonce) = zkos_verifier::transcript::Blake2sTranscript::search_pow(&seed, POW_BITS, &worker);
 //     let pow_nonce: u64 = 280946043;
-//     println!("pow_nonce: {}", pow_nonce);
+//     tracing::info!("pow_nonce: {}", pow_nonce);
 //     // let mut transcript_hasher = zkos_verifier::blake2s_u32::Blake2sState::new();
 //     risc_verifier::transcript::Blake2sTranscript::verify_pow_using_hasher(
 //         &mut transcript_hasher,

--- a/wrapper/src/tests/blake2s_tests.rs
+++ b/wrapper/src/tests/blake2s_tests.rs
@@ -397,7 +397,7 @@ fn test_leaf_inclusion() {
     let cs = &mut owned_cs;
 
     // read proof and set iterator
-    let risc_proof = deserialize_from_file(RISC_PROOF_PATH);
+    let risc_proof = deserialize_from_file(RISC_PROOF_PATH).unwrap();
     let shuffle_ram_inits_and_teardowns_len =
         crate::inner_verifiers::unified_reduced::imports::VERIFIER_COMPILED_LAYOUT
             .memory_layout

--- a/wrapper/src/tests/compression_tests.rs
+++ b/wrapper/src/tests/compression_tests.rs
@@ -4,8 +4,9 @@ use super::*;
 pub(crate) fn compression_full_test() {
     let worker = boojum::worker::Worker::new();
 
-    let risc_wrapper_proof = deserialize_from_file(RISC_WRAPPER_PROOF_PATH);
-    let risc_wrapper_vk: crate::RiscWrapperVK = deserialize_from_file(RISC_WRAPPER_VK_PATH);
+    let risc_wrapper_proof = deserialize_from_file(RISC_WRAPPER_PROOF_PATH).unwrap();
+    let risc_wrapper_vk: crate::RiscWrapperVK =
+        deserialize_from_file(RISC_WRAPPER_VK_PATH).unwrap();
 
     #[cfg(not(feature = "gpu"))]
     let (compression_proof, compression_vk) = {
@@ -62,15 +63,15 @@ pub(crate) fn compression_full_test() {
         (compression_proof, gpu_vk)
     };
 
-    serialize_to_file(&compression_proof, COMPRESSION_PROOF_PATH);
-    serialize_to_file(&compression_vk, COMPRESSION_VK_PATH);
+    serialize_to_file(&compression_proof, COMPRESSION_PROOF_PATH).unwrap();
+    serialize_to_file(&compression_vk, COMPRESSION_VK_PATH).unwrap();
 }
 
 #[test]
 pub(crate) fn compression_setup_test() {
     let worker = boojum::worker::Worker::new();
 
-    let risc_wrapper_vk = deserialize_from_file(RISC_WRAPPER_VK_PATH);
+    let risc_wrapper_vk = deserialize_from_file(RISC_WRAPPER_VK_PATH).unwrap();
 
     let (
         finalization_hint,
@@ -84,5 +85,5 @@ pub(crate) fn compression_setup_test() {
 
     dbg!(finalization_hint);
 
-    serialize_to_file(&compression_vk, COMPRESSION_VK_PATH);
+    serialize_to_file(&compression_vk, COMPRESSION_VK_PATH).unwrap();
 }

--- a/wrapper/src/tests/mod.rs
+++ b/wrapper/src/tests/mod.rs
@@ -48,7 +48,7 @@ mod snark_wrapper_tests;
 
 #[test]
 fn all_layers_full_test() {
-    println!("Testing Risc wrapper");
+    tracing::info!("Testing Risc wrapper");
     risc_wrapper_tests::risc_wrapper_full_test();
     // These tests may use a lot of memory, so we can try to free up some space afterwards.
     // It is especially important on CI machines.
@@ -57,9 +57,9 @@ fn all_layers_full_test() {
         libc::malloc_trim(0);
     }
 
-    println!("Testing compression");
+    tracing::info!("Testing compression");
     compression_tests::compression_full_test();
-    println!("Testing Snark wrapper");
+    tracing::info!("Testing Snark wrapper");
     snark_wrapper_tests::snark_wrapper_full_test();
 }
 

--- a/wrapper/src/tests/risc_wrapper_tests.rs
+++ b/wrapper/src/tests/risc_wrapper_tests.rs
@@ -20,7 +20,7 @@ pub(crate) fn risc_wrapper_full_test() {
     dbg!(binary_commitment);
 
     let program_proof: execution_utils::unrolled::UnrolledProgramProof =
-        deserialize_from_file(RISC_PROOF_PATH);
+        deserialize_from_file(RISC_PROOF_PATH).unwrap();
 
     let risc_wrapper_witness =
         RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment);
@@ -76,8 +76,8 @@ pub(crate) fn risc_wrapper_full_test() {
         (risc_wrapper_proof, gpu_vk)
     };
 
-    serialize_to_file(&risc_wrapper_proof, RISC_WRAPPER_PROOF_PATH);
-    serialize_to_file(&risc_wrapper_vk, RISC_WRAPPER_VK_PATH);
+    serialize_to_file(&risc_wrapper_proof, RISC_WRAPPER_PROOF_PATH).unwrap();
+    serialize_to_file(&risc_wrapper_vk, RISC_WRAPPER_VK_PATH).unwrap();
 }
 
 #[test]
@@ -88,7 +88,7 @@ pub(crate) fn risc_wrapper_setup_test() {
     let (_finalization_hint, _setup_base, _setup, vk, _setup_tree, _vars_hint, _witness_hints) =
         crate::get_risc_wrapper_setup(&worker, binary_commitment);
 
-    serialize_to_file(&vk, RISC_WRAPPER_VK_PATH);
+    serialize_to_file(&vk, RISC_WRAPPER_VK_PATH).unwrap();
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn test_verifier_inner_function() {
     let path = "testing_data/unified_proof_for_hashed_fibonacci.json";
     // let path = "testing_data/risc_proof_80sb.json";
     let program_proof: execution_utils::unrolled::UnrolledProgramProof =
-        deserialize_from_file(path);
+        deserialize_from_file(path).unwrap();
     let binary_commitment = BinaryCommitment::from_default_binary();
 
     let risc_wrapper_witness =

--- a/wrapper/src/tests/size_estimator.rs
+++ b/wrapper/src/tests/size_estimator.rs
@@ -126,9 +126,10 @@ fn find_minimum_cs_parameters_for_wrapper() {
         .and_then(|v| v.parse().ok())
         .unwrap_or(180);
 
-    println!(
+    tracing::info!(
         "Starting parameters: num_columns={}, num_repetitions={}",
-        num_columns, num_repetitions
+        num_columns,
+        num_repetitions
     );
 
     // Clear/create output directory
@@ -145,7 +146,7 @@ fn find_minimum_cs_parameters_for_wrapper() {
     }));
 
     // Search 1: minimum num_columns_under_copy_permutation (with fixed num_repetitions)
-    println!(
+    tracing::info!(
         "=== Searching for minimum num_columns_under_copy_permutation (num_repetitions={}) ===",
         num_repetitions
     );
@@ -156,11 +157,11 @@ fn find_minimum_cs_parameters_for_wrapper() {
         print!("  Trying num_columns={}... ", mid);
         match try_synthesize_wrapper_with_params(mid, num_repetitions) {
             Ok(()) => {
-                println!("OK");
+                tracing::info!("OK");
                 high = mid;
             }
             Err(msg) => {
-                println!("FAILED");
+                tracing::info!("FAILED");
                 let hook_info = panic_buf.lock().unwrap().clone();
                 let filename = format!(
                     "{}/wrapper_cols{}_reps{}_FAILED.txt",
@@ -179,10 +180,10 @@ fn find_minimum_cs_parameters_for_wrapper() {
             }
         }
     }
-    println!("Minimum num_columns_under_copy_permutation: {}\n", low);
+    tracing::info!("Minimum num_columns_under_copy_permutation: {}\n", low);
 
     // Search 2: minimum num_repetitions (with fixed num_columns)
-    println!(
+    tracing::info!(
         "=== Searching for minimum num_repetitions (num_columns_under_copy_permutation={}) ===",
         num_columns
     );
@@ -193,11 +194,11 @@ fn find_minimum_cs_parameters_for_wrapper() {
         print!("  Trying num_repetitions={}... ", mid);
         match try_synthesize_wrapper_with_params(num_columns, mid) {
             Ok(()) => {
-                println!("OK");
+                tracing::info!("OK");
                 high = mid;
             }
             Err(msg) => {
-                println!("FAILED");
+                tracing::info!("FAILED");
                 let hook_info = panic_buf.lock().unwrap().clone();
                 let filename = format!(
                     "{}/wrapper_cols{}_reps{}_FAILED.txt",
@@ -216,7 +217,7 @@ fn find_minimum_cs_parameters_for_wrapper() {
             }
         }
     }
-    println!("Minimum num_repetitions: {}", low);
+    tracing::info!("Minimum num_repetitions: {}", low);
 
     // Restore default panic hook
     std::panic::set_hook(default_hook);
@@ -284,7 +285,7 @@ fn find_minimum_cs_parameters_for_compression() {
         // Linear scan: for each possible num_columns_under_copy_permutation,
         // test with num_witness_columns = num_total_columns - copy_cols.
         // The working range may not be contiguous — it could be [x..y].
-        println!(
+        tracing::info!(
             "=== Scanning all splits for num_total_columns={} ===",
             num_total_columns
         );
@@ -299,12 +300,12 @@ fn find_minimum_cs_parameters_for_compression() {
             );
             match try_synthesize_compression_with_params(copy_cols, witness_cols, &vk) {
                 Ok(()) => {
-                    println!("OK");
+                    tracing::info!("OK");
                     min_copy_cols = Some(copy_cols);
                     break;
                 }
                 Err(msg) => {
-                    println!("FAILED");
+                    tracing::info!("FAILED");
                     let hook_info = panic_buf.lock().unwrap().clone();
                     let filename = format!(
                         "{}/compression_cols{}_wcols{}_FAILED.txt",
@@ -323,17 +324,17 @@ fn find_minimum_cs_parameters_for_compression() {
             }
         }
 
-        println!(
+        tracing::info!(
             "\n=== Results for CompressionCircuit (num_total_columns={}) ===",
             num_total_columns
         );
         if let Some(copy_cols) = min_copy_cols {
             let witness_cols = num_total_columns - copy_cols;
-            println!("  min num_columns_under_copy_permutation: {}", copy_cols);
-            println!("  max num_witness_columns: {}", witness_cols);
+            tracing::info!("  min num_columns_under_copy_permutation: {}", copy_cols);
+            tracing::info!("  max num_witness_columns: {}", witness_cols);
             break;
         } else {
-            println!("  No working configuration found, trying next total...");
+            tracing::info!("  No working configuration found, trying next total...");
         }
     }
 

--- a/wrapper/src/tests/size_estimator.rs
+++ b/wrapper/src/tests/size_estimator.rs
@@ -266,7 +266,7 @@ fn try_synthesize_compression_with_params(
 #[test]
 // #[ignore]
 fn find_minimum_cs_parameters_for_compression() {
-    let vk: crate::RiscWrapperVK = deserialize_from_file(RISC_WRAPPER_VK_PATH);
+    let vk: crate::RiscWrapperVK = deserialize_from_file(RISC_WRAPPER_VK_PATH).unwrap();
 
     // Clear/create output directory
     let _ = fs::remove_dir_all(SIZE_ESTIMATOR_OUTPUT_DIR);

--- a/wrapper/src/tests/snark_wrapper_tests.rs
+++ b/wrapper/src/tests/snark_wrapper_tests.rs
@@ -5,8 +5,8 @@ use bellman::kate_commitment::{Crs, CrsForMonomialForm};
 pub(crate) fn snark_wrapper_full_test() {
     let worker = crate::BellmanWorker::new();
 
-    let compression_proof = deserialize_from_file(COMPRESSION_PROOF_PATH);
-    let compression_vk: crate::CompressionVK = deserialize_from_file(COMPRESSION_VK_PATH);
+    let compression_proof = deserialize_from_file(COMPRESSION_PROOF_PATH).unwrap();
+    let compression_vk: crate::CompressionVK = deserialize_from_file(COMPRESSION_VK_PATH).unwrap();
     let crs_mons = Crs::<crate::Bn256, CrsForMonomialForm>::crs_42(
         1 << crate::L1_VERIFIER_DOMAIN_SIZE_LOG,
         &worker,
@@ -28,15 +28,15 @@ pub(crate) fn snark_wrapper_full_test() {
 
     assert!(is_valid);
 
-    serialize_to_file(&snark_wrapper_proof, SNARK_WRAPPER_PROOF_PATH);
-    serialize_to_file(&snark_wrapper_vk, SNARK_WRAPPER_VK_PATH);
+    serialize_to_file(&snark_wrapper_proof, SNARK_WRAPPER_PROOF_PATH).unwrap();
+    serialize_to_file(&snark_wrapper_vk, SNARK_WRAPPER_VK_PATH).unwrap();
 }
 
 #[test]
 pub(crate) fn snark_wrapper_setup_test() {
     let worker = crate::BellmanWorker::new();
 
-    let compression_vk = deserialize_from_file(COMPRESSION_VK_PATH);
+    let compression_vk = deserialize_from_file(COMPRESSION_VK_PATH).unwrap();
     let crs_mons = Crs::<crate::Bn256, CrsForMonomialForm>::crs_42(
         1 << crate::L1_VERIFIER_DOMAIN_SIZE_LOG,
         &worker,
@@ -45,5 +45,5 @@ pub(crate) fn snark_wrapper_setup_test() {
     let (_snark_wrapper_setup, snark_wrapper_vk) =
         crate::get_snark_wrapper_setup(compression_vk, &crs_mons, &worker);
 
-    serialize_to_file(&snark_wrapper_vk, SNARK_WRAPPER_VK_PATH);
+    serialize_to_file(&snark_wrapper_vk, SNARK_WRAPPER_VK_PATH).unwrap();
 }

--- a/wrapper/tests/cli.rs
+++ b/wrapper/tests/cli.rs
@@ -53,12 +53,19 @@ fn data(name: &str) -> String {
 fn verify_risc_wrapper() {
     let output = run(&[
         "verify",
-        "--stage", "risc-wrapper",
-        "--proof", &data("risc_wrapper_proof_80sb"),
-        "--vk", &data("risc_wrapper_vk_80sb"),
+        "--stage",
+        "risc-wrapper",
+        "--proof",
+        &data("risc_wrapper_proof_80sb"),
+        "--vk",
+        &data("risc_wrapper_vk_80sb"),
     ]);
     let out = stdout(&output);
-    assert!(output.status.success(), "verify risc-wrapper failed: {out}{}", stderr(&output));
+    assert!(
+        output.status.success(),
+        "verify risc-wrapper failed: {out}{}",
+        stderr(&output)
+    );
     assert!(out.contains("VALID"), "expected VALID in output: {out}");
 }
 
@@ -66,12 +73,19 @@ fn verify_risc_wrapper() {
 fn verify_compression() {
     let output = run(&[
         "verify",
-        "--stage", "compression",
-        "--proof", &data("compression_proof_80sb"),
-        "--vk", &data("compression_vk_80sb"),
+        "--stage",
+        "compression",
+        "--proof",
+        &data("compression_proof_80sb"),
+        "--vk",
+        &data("compression_vk_80sb"),
     ]);
     let out = stdout(&output);
-    assert!(output.status.success(), "verify compression failed: {out}{}", stderr(&output));
+    assert!(
+        output.status.success(),
+        "verify compression failed: {out}{}",
+        stderr(&output)
+    );
     assert!(out.contains("VALID"), "expected VALID in output: {out}");
 }
 
@@ -79,24 +93,35 @@ fn verify_compression() {
 fn verify_snark() {
     let output = run(&[
         "verify",
-        "--stage", "snark",
-        "--proof", &data("snark_wrapper_proof_80sb"),
-        "--vk", &data("snark_wrapper_vk_80sb"),
+        "--stage",
+        "snark",
+        "--proof",
+        &data("snark_wrapper_proof_80sb"),
+        "--vk",
+        &data("snark_wrapper_vk_80sb"),
     ]);
     let out = stdout(&output);
-    assert!(output.status.success(), "verify snark failed: {out}{}", stderr(&output));
+    assert!(
+        output.status.success(),
+        "verify snark failed: {out}{}",
+        stderr(&output)
+    );
     assert!(out.contains("VALID"), "expected VALID in output: {out}");
 }
 
 #[test]
 fn vk_hash() {
-    let output = run(&[
-        "vk-hash",
-        "--vk", &data("snark_wrapper_vk_80sb"),
-    ]);
+    let output = run(&["vk-hash", "--vk", &data("snark_wrapper_vk_80sb")]);
     let out = stdout(&output);
-    assert!(output.status.success(), "vk-hash failed: {out}{}", stderr(&output));
-    assert!(out.contains("VK hash"), "expected 'VK hash' in output: {out}");
+    assert!(
+        output.status.success(),
+        "vk-hash failed: {out}{}",
+        stderr(&output)
+    );
+    assert!(
+        out.contains("VK hash"),
+        "expected 'VK hash' in output: {out}"
+    );
 }
 
 #[test]
@@ -104,28 +129,43 @@ fn verify_mismatched_proof_and_vk() {
     // Use snark proof with compression VK — should fail verification.
     let output = run(&[
         "verify",
-        "--stage", "snark",
-        "--proof", &data("snark_wrapper_proof_80sb"),
-        "--vk", &data("compression_vk_80sb"),
+        "--stage",
+        "snark",
+        "--proof",
+        &data("snark_wrapper_proof_80sb"),
+        "--vk",
+        &data("compression_vk_80sb"),
     ]);
-    assert!(!output.status.success(), "expected failure for mismatched proof/VK");
+    assert!(
+        !output.status.success(),
+        "expected failure for mismatched proof/VK"
+    );
 }
 
 #[test]
 fn verify_missing_file() {
     let output = run(&[
         "verify",
-        "--stage", "snark",
-        "--proof", "/nonexistent/proof.json",
-        "--vk", &data("snark_wrapper_vk_80sb"),
+        "--stage",
+        "snark",
+        "--proof",
+        "/nonexistent/proof.json",
+        "--vk",
+        &data("snark_wrapper_vk_80sb"),
     ]);
-    assert!(!output.status.success(), "expected failure for missing file");
+    assert!(
+        !output.status.success(),
+        "expected failure for missing file"
+    );
 }
 
 #[test]
 fn no_subcommand_shows_error() {
     let output = run(&[]);
-    assert!(!output.status.success(), "expected non-zero exit with no subcommand");
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit with no subcommand"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -138,15 +178,29 @@ fn prove_risc_wrapper() {
     let tmp = tempfile::tempdir().unwrap();
     let output = run(&[
         "prove-risc-wrapper",
-        "--proof", &data("risc_proof_80sb"),
-        "--bin", &data("risc_app.bin"),
-        "--text", &data("risc_app.text"),
-        "-o", tmp.path().to_str().unwrap(),
+        "--proof",
+        &data("risc_proof_80sb"),
+        "--bin",
+        &data("risc_app.bin"),
+        "--text",
+        &data("risc_app.text"),
+        "-o",
+        tmp.path().to_str().unwrap(),
     ]);
     let out = stdout(&output);
-    assert!(output.status.success(), "prove-risc-wrapper failed: {out}{}", stderr(&output));
-    assert!(tmp.path().join("risc_wrapper_proof.json").exists(), "missing risc_wrapper_proof.json");
-    assert!(tmp.path().join("risc_wrapper_vk.json").exists(), "missing risc_wrapper_vk.json");
+    assert!(
+        output.status.success(),
+        "prove-risc-wrapper failed: {out}{}",
+        stderr(&output)
+    );
+    assert!(
+        tmp.path().join("risc_wrapper_proof.json").exists(),
+        "missing risc_wrapper_proof.json"
+    );
+    assert!(
+        tmp.path().join("risc_wrapper_vk.json").exists(),
+        "missing risc_wrapper_vk.json"
+    );
 }
 
 #[test]
@@ -155,14 +209,27 @@ fn prove_compression() {
     let tmp = tempfile::tempdir().unwrap();
     let output = run(&[
         "prove-compression",
-        "--risc-wrapper-proof", &data("risc_wrapper_proof_80sb"),
-        "--risc-wrapper-vk", &data("risc_wrapper_vk_80sb"),
-        "-o", tmp.path().to_str().unwrap(),
+        "--risc-wrapper-proof",
+        &data("risc_wrapper_proof_80sb"),
+        "--risc-wrapper-vk",
+        &data("risc_wrapper_vk_80sb"),
+        "-o",
+        tmp.path().to_str().unwrap(),
     ]);
     let out = stdout(&output);
-    assert!(output.status.success(), "prove-compression failed: {out}{}", stderr(&output));
-    assert!(tmp.path().join("compression_proof.json").exists(), "missing compression_proof.json");
-    assert!(tmp.path().join("compression_vk.json").exists(), "missing compression_vk.json");
+    assert!(
+        output.status.success(),
+        "prove-compression failed: {out}{}",
+        stderr(&output)
+    );
+    assert!(
+        tmp.path().join("compression_proof.json").exists(),
+        "missing compression_proof.json"
+    );
+    assert!(
+        tmp.path().join("compression_vk.json").exists(),
+        "missing compression_vk.json"
+    );
 }
 
 #[test]
@@ -171,14 +238,27 @@ fn prove_snark() {
     let tmp = tempfile::tempdir().unwrap();
     let output = run(&[
         "prove-snark",
-        "--compression-proof", &data("compression_proof_80sb"),
-        "--compression-vk", &data("compression_vk_80sb"),
-        "-o", tmp.path().to_str().unwrap(),
+        "--compression-proof",
+        &data("compression_proof_80sb"),
+        "--compression-vk",
+        &data("compression_vk_80sb"),
+        "-o",
+        tmp.path().to_str().unwrap(),
     ]);
     let out = stdout(&output);
-    assert!(output.status.success(), "prove-snark failed: {out}{}", stderr(&output));
-    assert!(tmp.path().join("snark_proof.json").exists(), "missing snark_proof.json");
-    assert!(tmp.path().join("snark_vk.json").exists(), "missing snark_vk.json");
+    assert!(
+        output.status.success(),
+        "prove-snark failed: {out}{}",
+        stderr(&output)
+    );
+    assert!(
+        tmp.path().join("snark_proof.json").exists(),
+        "missing snark_proof.json"
+    );
+    assert!(
+        tmp.path().join("snark_vk.json").exists(),
+        "missing snark_vk.json"
+    );
     assert!(out.contains("VK hash"), "expected VK hash in output: {out}");
 }
 
@@ -188,22 +268,48 @@ fn prove_all_with_intermediates() {
     let tmp = tempfile::tempdir().unwrap();
     let output = run(&[
         "prove-all",
-        "--proof", &data("risc_proof_80sb"),
-        "--bin", &data("risc_app.bin"),
-        "--text", &data("risc_app.text"),
+        "--proof",
+        &data("risc_proof_80sb"),
+        "--bin",
+        &data("risc_app.bin"),
+        "--text",
+        &data("risc_app.text"),
         "--save-intermediates",
-        "-o", tmp.path().to_str().unwrap(),
+        "-o",
+        tmp.path().to_str().unwrap(),
     ]);
     let out = stdout(&output);
-    assert!(output.status.success(), "prove-all failed: {out}{}", stderr(&output));
+    assert!(
+        output.status.success(),
+        "prove-all failed: {out}{}",
+        stderr(&output)
+    );
     // Final outputs
-    assert!(tmp.path().join("snark_proof.json").exists(), "missing snark_proof.json");
-    assert!(tmp.path().join("snark_vk.json").exists(), "missing snark_vk.json");
+    assert!(
+        tmp.path().join("snark_proof.json").exists(),
+        "missing snark_proof.json"
+    );
+    assert!(
+        tmp.path().join("snark_vk.json").exists(),
+        "missing snark_vk.json"
+    );
     // Intermediates
-    assert!(tmp.path().join("risc_wrapper_proof.json").exists(), "missing risc_wrapper_proof.json");
-    assert!(tmp.path().join("risc_wrapper_vk.json").exists(), "missing risc_wrapper_vk.json");
-    assert!(tmp.path().join("compression_proof.json").exists(), "missing compression_proof.json");
-    assert!(tmp.path().join("compression_vk.json").exists(), "missing compression_vk.json");
+    assert!(
+        tmp.path().join("risc_wrapper_proof.json").exists(),
+        "missing risc_wrapper_proof.json"
+    );
+    assert!(
+        tmp.path().join("risc_wrapper_vk.json").exists(),
+        "missing risc_wrapper_vk.json"
+    );
+    assert!(
+        tmp.path().join("compression_proof.json").exists(),
+        "missing compression_proof.json"
+    );
+    assert!(
+        tmp.path().join("compression_vk.json").exists(),
+        "missing compression_vk.json"
+    );
     assert!(out.contains("VK hash"), "expected VK hash in output: {out}");
 }
 
@@ -211,14 +317,24 @@ fn prove_all_with_intermediates() {
 #[ignore]
 fn generate_vk() {
     let tmp = tempfile::tempdir().unwrap();
-    let output = run(&[
-        "generate-vk",
-        "-o", tmp.path().to_str().unwrap(),
-    ]);
+    let output = run(&["generate-vk", "-o", tmp.path().to_str().unwrap()]);
     let out = stdout(&output);
-    assert!(output.status.success(), "generate-vk failed: {out}{}", stderr(&output));
-    assert!(tmp.path().join("risc_wrapper_vk.json").exists(), "missing risc_wrapper_vk.json");
-    assert!(tmp.path().join("compression_vk.json").exists(), "missing compression_vk.json");
-    assert!(tmp.path().join("snark_vk.json").exists(), "missing snark_vk.json");
+    assert!(
+        output.status.success(),
+        "generate-vk failed: {out}{}",
+        stderr(&output)
+    );
+    assert!(
+        tmp.path().join("risc_wrapper_vk.json").exists(),
+        "missing risc_wrapper_vk.json"
+    );
+    assert!(
+        tmp.path().join("compression_vk.json").exists(),
+        "missing compression_vk.json"
+    );
+    assert!(
+        tmp.path().join("snark_vk.json").exists(),
+        "missing snark_vk.json"
+    );
     assert!(out.contains("VK hash"), "expected VK hash in output: {out}");
 }

--- a/wrapper_generator/src/main.rs
+++ b/wrapper_generator/src/main.rs
@@ -63,12 +63,12 @@ fn format_rust_code(code: &str) -> Result<String, String> {
 struct Cli {
     #[arg(
         long,
-        default_value = "../wrapper/src/inner_verifiers/unified_reduced/imports"
+        default_value = "wrapper/src/inner_verifiers/unified_reduced/imports"
     )]
     output_dir: String,
     #[arg(
         long,
-        default_value = "../wrapper/src/inner_verifiers/blake_delegation/imports"
+        default_value = "wrapper/src/inner_verifiers/blake_delegation/imports"
     )]
     blake_output_dir: String,
 }


### PR DESCRIPTION
This PR makes it easier to use this project as a library rather than a CLI:

- Moves contents of `main.rs` to a new `interface` module accessible through lib, with two parts:
  - `cmd`: "commands", aka "high-level actions", suitable for CLI use
  - `phases`: "phases", aka "building blocks", more suitable for integration.
- Slightly changes the code so that phases don't load proofs from filesystem but rather take deserialized ones, deserializing happens outside -- so proof can be passed in-memory there.
- Introduces `anyhow` and reduces the amount of panics, so that as a library it is possible to write fallible code without panicking (e.g. if something is wrong, log it and continue, rather than crash the whole application).
- Replaces `println` with `tracing`, so that in apps logs are shown only when they are explicitly enabled; logs are enabled by default for CLI.
- Adds `rust-toolchain.toml` to ensure that people use a consistent toolchain when working on the project.