### PR TITLE
feat: Optimize compilation speed

### DIFF
--- a/circuit_mersenne_field/src/extension_trait.rs
+++ b/circuit_mersenne_field/src/extension_trait.rs
@@ -13,18 +13,22 @@ pub trait CircuitFieldExpression<F: SmallField, BaseField> {
 }
 
 impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneField<F> {
+    #[inline(never)]
     fn add_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         self.add(cs, base)
     }
 
+    #[inline(never)]
     fn sub_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         self.sub(cs, base)
     }
 
+    #[inline(never)]
     fn mul_by_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         self.mul(cs, base)
     }
 
+    #[inline(never)]
     fn mul_by_base_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
@@ -36,6 +40,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneFiel
 }
 
 impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneComplex<F> {
+    #[inline(never)]
     fn add_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         Self {
             x: self.x.add(cs, base),
@@ -43,6 +48,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneComp
         }
     }
 
+    #[inline(never)]
     fn sub_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         Self {
             x: self.x.sub(cs, base),
@@ -50,6 +56,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneComp
         }
     }
 
+    #[inline(never)]
     fn mul_by_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         Self {
             x: self.x.mul(cs, base),
@@ -57,6 +64,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneComp
         }
     }
 
+    #[inline(never)]
     fn mul_by_base_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
@@ -71,6 +79,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneComp
 }
 
 impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneQuartic<F> {
+    #[inline(never)]
     fn add_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         Self {
             x: self.x.add_base(cs, base),
@@ -78,6 +87,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneQuar
         }
     }
 
+    #[inline(never)]
     fn sub_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         Self {
             x: self.x.sub_base(cs, base),
@@ -85,6 +95,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneQuar
         }
     }
 
+    #[inline(never)]
     fn mul_by_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneField<F>) -> Self {
         Self {
             x: self.x.mul_by_base(cs, base),
@@ -92,6 +103,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneQuar
         }
     }
 
+    #[inline(never)]
     fn mul_by_base_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
@@ -106,18 +118,22 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneField<F>> for MersenneQuar
 }
 
 impl<F: SmallField> CircuitFieldExpression<F, MersenneComplex<F>> for MersenneComplex<F> {
+    #[inline(never)]
     fn add_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneComplex<F>) -> Self {
         self.add(cs, base)
     }
 
+    #[inline(never)]
     fn sub_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneComplex<F>) -> Self {
         self.sub(cs, base)
     }
 
+    #[inline(never)]
     fn mul_by_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneComplex<F>) -> Self {
         self.mul(cs, base)
     }
 
+    #[inline(never)]
     fn mul_by_base_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
@@ -129,6 +145,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneComplex<F>> for MersenneCo
 }
 
 impl<F: SmallField> CircuitFieldExpression<F, MersenneComplex<F>> for MersenneQuartic<F> {
+    #[inline(never)]
     fn add_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneComplex<F>) -> Self {
         Self {
             x: self.x.add(cs, base),
@@ -136,6 +153,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneComplex<F>> for MersenneQu
         }
     }
 
+    #[inline(never)]
     fn sub_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneComplex<F>) -> Self {
         Self {
             x: self.x.sub(cs, base),
@@ -143,6 +161,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneComplex<F>> for MersenneQu
         }
     }
 
+    #[inline(never)]
     fn mul_by_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneComplex<F>) -> Self {
         Self {
             x: self.x.mul(cs, base),
@@ -150,6 +169,7 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneComplex<F>> for MersenneQu
         }
     }
 
+    #[inline(never)]
     fn mul_by_base_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,
@@ -164,18 +184,22 @@ impl<F: SmallField> CircuitFieldExpression<F, MersenneComplex<F>> for MersenneQu
 }
 
 impl<F: SmallField> CircuitFieldExpression<F, MersenneQuartic<F>> for MersenneQuartic<F> {
+    #[inline(never)]
     fn add_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneQuartic<F>) -> Self {
         self.add(cs, base)
     }
 
+    #[inline(never)]
     fn sub_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneQuartic<F>) -> Self {
         self.sub(cs, base)
     }
 
+    #[inline(never)]
     fn mul_by_base<CS: ConstraintSystem<F>>(&self, cs: &mut CS, base: &MersenneQuartic<F>) -> Self {
         self.mul(cs, base)
     }
 
+    #[inline(never)]
     fn mul_by_base_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,

--- a/circuit_mersenne_field/src/field.rs
+++ b/circuit_mersenne_field/src/field.rs
@@ -12,6 +12,7 @@ pub struct MersenneField<F: SmallField> {
 }
 
 impl<F: SmallField> MersenneField<F> {
+    #[inline(never)]
     pub fn zero<CS: ConstraintSystem<F>>(cs: &mut CS) -> Self {
         let variable = cs.allocate_constant(F::from_u64_unchecked(0));
 
@@ -22,6 +23,7 @@ impl<F: SmallField> MersenneField<F> {
         }
     }
 
+    #[inline(never)]
     pub fn one<CS: ConstraintSystem<F>>(cs: &mut CS) -> Self {
         let variable = cs.allocate_constant(F::from_u64_unchecked(1));
 
@@ -59,6 +61,7 @@ impl<F: SmallField> MersenneField<F> {
     }
 
     /// The value should be in range [0, 2^31 - 2]
+    #[inline(never)]
     pub fn from_variable_checked<CS: ConstraintSystem<F>>(
         cs: &mut CS,
         variable: Variable,
@@ -80,6 +83,7 @@ impl<F: SmallField> MersenneField<F> {
     }
 
     /// The value should be in range [0, 2^31 - 2]
+    #[inline(never)]
     pub fn allocate_checked_without_value<CS: ConstraintSystem<F>>(
         cs: &mut CS,
         reduced: bool,
@@ -89,6 +93,7 @@ impl<F: SmallField> MersenneField<F> {
         Self::from_variable_checked(cs, variable, reduced)
     }
 
+    #[inline(never)]
     pub fn allocate_checked<CS: ConstraintSystem<F>>(
         cs: &mut CS,
         witness: Mersenne31Field,
@@ -101,6 +106,7 @@ impl<F: SmallField> MersenneField<F> {
         Self::from_variable_checked(cs, variable, reduced)
     }
 
+    #[inline(never)]
     pub fn from_uint32_with_reduction<CS: ConstraintSystem<F>>(
         cs: &mut CS,
         value: UInt32<F>,
@@ -202,6 +208,10 @@ impl<F: SmallField> MersenneField<F> {
         self.reduced = true;
     }
 
+    // The generated inner verifiers call these arithmetic entry points thousands of
+    // times. Keeping them out-of-line avoids cloning their constraint-building logic
+    // into already enormous verifier functions.
+    #[inline(never)]
     pub fn add<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         // We will use the following system of constraints:
         // (1) self + other = tmp
@@ -255,6 +265,7 @@ impl<F: SmallField> MersenneField<F> {
         result
     }
 
+    #[inline(never)]
     pub fn double<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Self {
         // We will use the following system of constraints:
         // (1) 2 * self - reduce * modulus = result
@@ -306,6 +317,7 @@ impl<F: SmallField> MersenneField<F> {
         result
     }
 
+    #[inline(never)]
     pub fn negated<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Self {
         // We will use the following system of constraints:
         // (1) -self + reduce * modulus = result
@@ -358,6 +370,7 @@ impl<F: SmallField> MersenneField<F> {
         zero.sub(cs, self)
     }
 
+    #[inline(never)]
     pub fn sub<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         // We will use the following system of constraints:
         // (1) self - other = tmp
@@ -412,6 +425,7 @@ impl<F: SmallField> MersenneField<F> {
         result
     }
 
+    #[inline(never)]
     pub fn mul<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         // We will use the following system of constraints:
         // (1) self * other = result + reduce * modulus
@@ -628,6 +642,7 @@ impl<F: SmallField> MersenneField<F> {
     }
 
     /// Computes self * other_mul + other_add
+    #[inline(never)]
     pub fn mul_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,

--- a/circuit_mersenne_field/src/fourth_ext.rs
+++ b/circuit_mersenne_field/src/fourth_ext.rs
@@ -10,6 +10,7 @@ pub struct MersenneQuartic<F: SmallField> {
 }
 
 impl<F: SmallField> MersenneQuartic<F> {
+    #[inline(never)]
     pub fn zero<CS: ConstraintSystem<F>>(cs: &mut CS) -> Self {
         Self {
             x: MersenneComplex::zero(cs),
@@ -17,6 +18,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         }
     }
 
+    #[inline(never)]
     pub fn one<CS: ConstraintSystem<F>>(cs: &mut CS) -> Self {
         Self {
             x: MersenneComplex::one(cs),
@@ -66,6 +68,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         [self.x.x, self.x.y, self.y.x, self.y.y]
     }
 
+    #[inline(never)]
     pub fn from_coeffs(coefficients: [MersenneField<F>; 4]) -> Self {
         Self {
             x: MersenneComplex::from_coeffs(coefficients[0..2].try_into().unwrap()),
@@ -109,6 +112,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         self.y.enforce_reduced(cs);
     }
 
+    #[inline(never)]
     pub fn from_base<CS: ConstraintSystem<F>>(cs: &mut CS, value: MersenneField<F>) -> Self {
         Self {
             x: MersenneComplex::from_base(cs, value),
@@ -116,6 +120,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         }
     }
 
+    #[inline(never)]
     pub fn from_complex<CS: ConstraintSystem<F>>(cs: &mut CS, value: MersenneComplex<F>) -> Self {
         Self {
             x: value,
@@ -123,6 +128,9 @@ impl<F: SmallField> MersenneQuartic<F> {
         }
     }
 
+    // The generated quotient evaluators are dominated by quartic arithmetic. Marking
+    // these wrappers as out-of-line keeps LLVM from duplicating them at every call site.
+    #[inline(never)]
     pub fn add<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         Self {
             x: self.x.add(cs, &other.x),
@@ -130,6 +138,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         }
     }
 
+    #[inline(never)]
     pub fn double<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Self {
         Self {
             x: self.x.double(cs),
@@ -137,6 +146,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         }
     }
 
+    #[inline(never)]
     pub fn sub<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         Self {
             x: self.x.sub(cs, &other.x),
@@ -144,6 +154,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         }
     }
 
+    #[inline(never)]
     pub fn negated<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Self {
         Self {
             x: self.x.negated(cs),
@@ -151,6 +162,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         }
     }
 
+    #[inline(never)]
     pub fn mul<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         // (a + bj)(c + dj) = (ac + kbd) + (ad + bc)j
         let kbd = self.y.mul(cs, &other.y).mul_by_non_residue(cs);
@@ -162,6 +174,7 @@ impl<F: SmallField> MersenneQuartic<F> {
         }
     }
 
+    #[inline(never)]
     pub fn mul_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,

--- a/circuit_mersenne_field/src/second_ext.rs
+++ b/circuit_mersenne_field/src/second_ext.rs
@@ -10,6 +10,7 @@ pub struct MersenneComplex<F: SmallField> {
 }
 
 impl<F: SmallField> MersenneComplex<F> {
+    #[inline(never)]
     pub fn zero<CS: ConstraintSystem<F>>(cs: &mut CS) -> Self {
         Self {
             x: MersenneField::zero(cs),
@@ -17,6 +18,7 @@ impl<F: SmallField> MersenneComplex<F> {
         }
     }
 
+    #[inline(never)]
     pub fn one<CS: ConstraintSystem<F>>(cs: &mut CS) -> Self {
         Self {
             x: MersenneField::one(cs),
@@ -91,6 +93,7 @@ impl<F: SmallField> MersenneComplex<F> {
         self.y.enforce_reduced(cs);
     }
 
+    #[inline(never)]
     pub fn from_coeffs(coefficients: [MersenneField<F>; 2]) -> Self {
         Self {
             x: coefficients[0],
@@ -98,6 +101,7 @@ impl<F: SmallField> MersenneComplex<F> {
         }
     }
 
+    #[inline(never)]
     pub fn from_base<CS: ConstraintSystem<F>>(cs: &mut CS, value: MersenneField<F>) -> Self {
         Self {
             x: value,
@@ -105,6 +109,9 @@ impl<F: SmallField> MersenneComplex<F> {
         }
     }
 
+    // Quartic arithmetic funnels through the quadratic extension, so these wrappers
+    // are also hot compile-time expansion points when verifier code is generated.
+    #[inline(never)]
     pub fn add<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         Self {
             x: self.x.add(cs, &other.x),
@@ -112,6 +119,7 @@ impl<F: SmallField> MersenneComplex<F> {
         }
     }
 
+    #[inline(never)]
     pub fn double<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Self {
         Self {
             x: self.x.double(cs),
@@ -119,6 +127,7 @@ impl<F: SmallField> MersenneComplex<F> {
         }
     }
 
+    #[inline(never)]
     pub fn sub<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         Self {
             x: self.x.sub(cs, &other.x),
@@ -126,6 +135,7 @@ impl<F: SmallField> MersenneComplex<F> {
         }
     }
 
+    #[inline(never)]
     pub fn negated<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Self {
         Self {
             x: self.x.negated(cs),
@@ -133,6 +143,7 @@ impl<F: SmallField> MersenneComplex<F> {
         }
     }
 
+    #[inline(never)]
     pub fn mul<CS: ConstraintSystem<F>>(&self, cs: &mut CS, other: &Self) -> Self {
         Self {
             x: self.x.two_mul_and_sub(cs, &other.x, &other.y, &self.y),
@@ -140,6 +151,7 @@ impl<F: SmallField> MersenneComplex<F> {
         }
     }
 
+    #[inline(never)]
     pub fn mul_and_add<CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(allocator_api)]
 #![allow(incomplete_features)]
+#![allow(unsafe_op_in_unsafe_fn)]
 #![feature(generic_const_exprs)]
 
 pub mod circuits;


### PR DESCRIPTION
1. Allow a particular warning, since it was generated over 6000 times when compiling.
2. Add `#[inline(never)]` on some field methods, because right now LLVM tries to inline them as they're trivial, but generated verifiers are so huge that it causes rust compiler to go wild.

Result: compile time 20 minutes -> 1 minute on my machine. 