### PR TITLE
feat: cap shivini device-memory pool via env var and --max-device-allocation flag

### DIFF
--- a/wrapper/src/gpu/context.rs
+++ b/wrapper/src/gpu/context.rs
@@ -1,0 +1,14 @@
+//! Shivini-side glue: apply the optional device-memory cap to a `ProverContextConfig`.
+
+use shivini::ProverContextConfig;
+
+use crate::gpu_config::max_device_allocation;
+
+/// Layer the configured `max_device_allocation` (from CLI flag or env var) onto an
+/// existing shivini config. A no-op when no cap is set.
+pub fn apply_env_overrides(base: ProverContextConfig) -> ProverContextConfig {
+    match max_device_allocation() {
+        Some(bytes) => base.with_maximum_device_allocation(bytes),
+        None => base,
+    }
+}

--- a/wrapper/src/gpu/mod.rs
+++ b/wrapper/src/gpu/mod.rs
@@ -1,3 +1,4 @@
 pub mod compression;
+pub mod context;
 pub mod risc_wrapper;
 pub mod snark;

--- a/wrapper/src/gpu_config.rs
+++ b/wrapper/src/gpu_config.rs
@@ -1,0 +1,116 @@
+//! Optional cap on shivini's GPU device-memory pool.
+//!
+//! Two channels feed the cap:
+//! - the `ZKOS_WRAPPER_MAX_DEVICE_ALLOCATION` env var;
+//! - [`set_max_device_allocation`], called from the wrapper binary's
+//!   `--max-device-allocation` flag before any GPU code runs.
+//!
+//! The CLI setter takes precedence; the result is cached in a `OnceLock` so the value
+//! is parsed once. Lives outside the `gpu` feature gate so it remains usable in
+//! non-GPU builds (the CLI flag is global).
+
+use std::sync::OnceLock;
+
+pub const MAX_DEVICE_ALLOCATION_ENV: &str = "ZKOS_WRAPPER_MAX_DEVICE_ALLOCATION";
+
+static MAX_DEVICE_ALLOCATION: OnceLock<Option<usize>> = OnceLock::new();
+
+/// Cap shivini's device-memory pool at `bytes`. Idempotent and first-writer-wins, so
+/// callers should invoke this before any `ProverContext::create*` call site.
+pub fn set_max_device_allocation(bytes: usize) {
+    let _ = MAX_DEVICE_ALLOCATION.set(Some(bytes));
+}
+
+/// Returns the cap if one was supplied via `set_max_device_allocation` or the env var.
+/// Panics on env-var parse errors so misconfiguration fails fast at startup.
+pub fn max_device_allocation() -> Option<usize> {
+    *MAX_DEVICE_ALLOCATION.get_or_init(|| {
+        let raw = std::env::var(MAX_DEVICE_ALLOCATION_ENV).ok()?;
+        Some(
+            parse_byte_size(&raw)
+                .unwrap_or_else(|e| panic!("invalid {MAX_DEVICE_ALLOCATION_ENV}={raw:?}: {e}")),
+        )
+    })
+}
+
+/// Parse a Kubernetes-style byte size: `1024`, `512Mi`, `32Gi`, `32GiB`, `2G`, `2GB`, etc.
+///
+/// Rules:
+/// - No suffix → raw bytes
+/// - `K`/`M`/`G`/`T` (optionally with trailing `B`) → decimal (10^3, 10^6, 10^9, 10^12)
+/// - `Ki`/`Mi`/`Gi`/`Ti` (optionally with trailing `B`) → binary (2^10, 2^20, 2^30, 2^40)
+/// - Whitespace and case are ignored.
+pub fn parse_byte_size(input: &str) -> Result<usize, String> {
+    let s: String = input.chars().filter(|c| !c.is_whitespace()).collect();
+    if s.is_empty() {
+        return Err("empty value".into());
+    }
+
+    let split_at = s
+        .find(|c: char| !(c.is_ascii_digit() || c == '.'))
+        .unwrap_or(s.len());
+    let (num, unit) = s.split_at(split_at);
+    if num.is_empty() {
+        return Err(format!("no numeric prefix in {input:?}"));
+    }
+    let value: f64 = num
+        .parse()
+        .map_err(|e| format!("bad number {num:?}: {e}"))?;
+    if !value.is_finite() || value < 0.0 {
+        return Err(format!("value must be finite and non-negative: {input:?}"));
+    }
+
+    let multiplier: u64 = match unit.to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "k" | "kb" => 1_000,
+        "m" | "mb" => 1_000_000,
+        "g" | "gb" => 1_000_000_000,
+        "t" | "tb" => 1_000_000_000_000,
+        "ki" | "kib" => 1 << 10,
+        "mi" | "mib" => 1 << 20,
+        "gi" | "gib" => 1 << 30,
+        "ti" | "tib" => 1 << 40,
+        other => return Err(format!("unknown size suffix {other:?}")),
+    };
+
+    let bytes = value * multiplier as f64;
+    if bytes > usize::MAX as f64 {
+        return Err(format!("value overflows usize: {input:?}"));
+    }
+    Ok(bytes as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_raw_bytes() {
+        assert_eq!(parse_byte_size("1024").unwrap(), 1024);
+        assert_eq!(parse_byte_size("0").unwrap(), 0);
+    }
+
+    #[test]
+    fn parses_decimal_suffixes() {
+        assert_eq!(parse_byte_size("1K").unwrap(), 1_000);
+        assert_eq!(parse_byte_size("2MB").unwrap(), 2_000_000);
+        assert_eq!(parse_byte_size("3 g").unwrap(), 3_000_000_000);
+        assert_eq!(parse_byte_size("4tb").unwrap(), 4_000_000_000_000);
+    }
+
+    #[test]
+    fn parses_binary_suffixes() {
+        assert_eq!(parse_byte_size("1Ki").unwrap(), 1024);
+        assert_eq!(parse_byte_size("2MiB").unwrap(), 2 << 20);
+        assert_eq!(parse_byte_size("32Gi").unwrap(), 32usize << 30);
+        assert_eq!(parse_byte_size("20 GiB").unwrap(), 20usize << 30);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(parse_byte_size("").is_err());
+        assert!(parse_byte_size("GiB").is_err());
+        assert!(parse_byte_size("12XB").is_err());
+        assert!(parse_byte_size("-1").is_err());
+    }
+}

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -10,6 +10,7 @@ compile_error!("features `security_80` and `security_100` are mutually exclusive
 compile_error!("one of `security_80` or `security_100` must be enabled");
 
 pub mod circuits;
+pub mod gpu_config;
 mod inner_verifiers;
 pub mod interface;
 pub mod transcript;
@@ -576,8 +577,9 @@ pub fn prove_risc_wrapper_with_snark(
 
     #[cfg(feature = "gpu")]
     let (compression_proof, compression_vk) = {
-        let config =
-            shivini::ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+        let config = crate::gpu::context::apply_env_overrides(
+            shivini::ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15),
+        );
         let _prover_context = shivini::ProverContext::create_with_config(config).unwrap();
 
         let (setup, compression_vk, finalization) =

--- a/wrapper/src/main.rs
+++ b/wrapper/src/main.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
+use zkos_wrapper::gpu_config::{parse_byte_size, set_max_device_allocation};
 use zkos_wrapper::interface;
 
 #[derive(Parser)]
@@ -17,6 +18,13 @@ struct Cli {
     /// Number of worker threads (defaults to all available cores)
     #[arg(long, global = true)]
     threads: Option<usize>,
+
+    /// Cap shivini's GPU device memory pool. Accepts decimal (`32G`, `32GB`) or
+    /// binary (`32Gi`, `32GiB`) Kubernetes-style sizes; bare integers are bytes.
+    /// When unset, falls back to the `ZKOS_WRAPPER_MAX_DEVICE_ALLOCATION` env var,
+    /// then to shivini's default (grab all free device memory).
+    #[arg(long, global = true, value_parser = parse_byte_size)]
+    max_device_allocation: Option<usize>,
 
     #[command(subcommand)]
     command: Commands,
@@ -205,6 +213,10 @@ fn main() -> anyhow::Result<()> {
     init_tracing()?;
 
     let cli = Cli::parse();
+
+    if let Some(bytes) = cli.max_device_allocation {
+        set_max_device_allocation(bytes);
+    }
 
     match cli.command {
         Commands::ProveAll {

--- a/wrapper/src/wrapper/gpu.rs
+++ b/wrapper/src/wrapper/gpu.rs
@@ -7,6 +7,7 @@ use shivini::cs::GpuSetup;
 use shivini::{ProverContext, ProverContextConfig};
 
 use crate::circuits::{BinaryCommitment, RiscWrapperWitness};
+use crate::gpu::context::apply_env_overrides;
 use crate::{
     BoojumWorker, CompressionProof, CompressionTreeHasher, CompressionVK, RiscWrapperProof,
     RiscWrapperTreeHasher, RiscWrapperVK, SnarkWrapperProof, SnarkWrapperVK,
@@ -334,8 +335,9 @@ impl BackendState {
             // Both STARK phases use shivini's process-global context. Use the
             // smallest domain required by phase 2 so one context can serve phase
             // 1 and phase 2 for a single FRI -> SNARK pipeline iteration.
-            let config =
-                ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15);
+            let config = apply_env_overrides(
+                ProverContextConfig::default().with_smallest_supported_domain_size(1 << 15),
+            );
             self.stark_context = Some(
                 ProverContext::create_with_config(config)
                     .context("while attempting to initialize the STARK GPU prover context")?,


### PR DESCRIPTION
## What ❔

Adds an opt-in cap on shivini's GPU device-memory pool, exposed two ways:

- A new env var `ZKOS_WRAPPER_MAX_DEVICE_ALLOCATION` (Kubernetes-style sizes: `32Gi`, `48GiB`, `64G`, or raw bytes).
- A new global CLI flag `--max-device-allocation` on the `wrapper` binary, which seeds the same value before any GPU code runs.

When a cap is provided, both `ProverContext::create_with_config` sites — `wrapper/src/wrapper/gpu.rs::ensure_stark_context` (the cached `stark_context` shared across phases 1+2) and the inline path in `wrapper/src/lib.rs` (`prove_risc_wrapper_with_snark`) — thread it through `ProverContextConfig::with_maximum_device_allocation`. When neither is set, behavior is identical to today (shivini grabs all free device memory).

New modules:
- `wrapper/src/gpu_config.rs` — env-var constant, `parse_byte_size` (K8s-style suffix parser), `set_max_device_allocation` / `max_device_allocation` (cached via `OnceLock`), unit tests. Lives **outside** the `gpu` feature gate so non-GPU builds still parse the CLI value and so library callers can seed the cap without depending on shivini.
- `wrapper/src/gpu/context.rs` — single helper `apply_env_overrides(base)`, gated behind `gpu`.

The CLI setter takes precedence over the env var when both are provided; the resolved value is cached in a `OnceLock` so the env var is parsed at most once.

## Why ❔

The default shivini pool grabs ~47 GB up front for the SNARK precomputation, and the subsequent `get_light_setup` / `gpu_setup_and_vk_from_base_setup_vk_params_and_hints` needs another large device buffer for the LDE table and Merkle caps — total ~60–70 GB of free VRAM on a single contiguous device.

This is fine on H200 (141 GB HBM3e), but breaks on:

- **NVIDIA RTX PRO 6000 Blackwell (96 GB) under MIG**, where the largest commonly-used slice is `2g.48gb` — the pool itself barely fits and the next allocation OOMs in shivini with `ErrorMemoryAllocation`.
- **H100 80 GB**, which is borderline and OOMs in many shared-GPU configurations.

The failure surfaces as a panic out of shivini at the SNARK setup stage:

```
allocated 1048576 bytes on device
allocated 50398756864 bytes on device      (~46.9 GB, succeeds)
allocated 65536 bytes on host
allocated 2147483648 bytes on host         (2 GB pinned)
thread 'main' panicked ... ErrorMemoryAllocation
```

| GPU                                      | VRAM   | Result |
|------------------------------------------|--------|--------|
| H200                                     | 141 GB | works  |
| H100 80 GB                               | 80 GB  | OOM (borderline) |
| RTX PRO 6000 Blackwell, full card        | 96 GB  | works  |
| RTX PRO 6000 Blackwell, MIG `2g.48gb`    | 48 GB  | OOM    |
| RTX PRO 6000 Blackwell, MIG `1g.24gb`    | 24 GB  | OOM    |

FRI proving fits comfortably on the smaller slices; only the SNARK pipeline trips this.

Capping the pool (e.g. `--max-device-allocation 21Gi` or `ZKOS_WRAPPER_MAX_DEVICE_ALLOCATION=21Gi`) leaves headroom for the setup buffers, and SNARK proving completes on smaller GPUs / MIG slices. The flag is opt-in; operators running on a full H200 do not need to change anything.

The two-channel design (env var + CLI) is deliberate: downstream services that embed `zkos-wrapper` as a library (running outside the wrapper binary, e.g. in Kubernetes-managed snark-prover pods) need the env var; operators driving the binary directly want a flag. Both feed the same `OnceLock`.

## Is this a breaking change?

- [ ] Yes
- [x] No — purely additive. New public surface: one constant, two free functions, one new module (`gpu_config`), one new submodule (`gpu::context`), one new global CLI flag, one new env var. Default behavior when both are absent is byte-identical to before.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated. (`parse_byte_size` unit tests in `wrapper/src/gpu_config.rs` — 4 tests covering raw bytes, decimal suffixes, binary suffixes, and rejected garbage.)
- [x] Documentation comments have been added / updated. (Module-level `//!` docs on both new modules; `///` help string on the CLI flag explaining unit formats and precedence.)
- [x] Code has been formatted. (`cargo fmt --check` clean on the project-pinned `nightly-2026-02-10` toolchain.)
