### PR TITLE
feat: Check aux_params inside wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,11 @@ jobs:
         # We need to increase the stack size for the tests (due to quotient computation)
         run:  RUST_MIN_STACK=67108864 cargo test all_layers_full_test --release -- --nocapture
       - name: check_aux_params tests
-        # Exercises the --check-aux-params off-circuit validation (both the
-        # matching and mismatched cases), which the full test above does not cover.
-        run:  RUST_MIN_STACK=67108864 cargo test check_aux_params_off_circuit_validation --release -- --nocapture
+        # Exercises the --check-aux-params path, which the full test above does not
+        # cover: the off-circuit validation (matching and mismatched aux_params)
+        # and the in-circuit constraints (prepare_and_allocate_public_inputs with
+        # check_aux_params = true, plus the direct PI packing).
+        run:  RUST_MIN_STACK=67108864 cargo test --release -- --nocapture check_aux_params_off_circuit_validation test_verifier_inner_function_check_aux_params
 
   mersenne_tests:
     name: mersenne_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       - name: tests
         # We need to increase the stack size for the tests (due to quotient computation)
         run:  RUST_MIN_STACK=67108864 cargo test all_layers_full_test --release -- --nocapture
+      - name: check_aux_params tests
+        # Exercises the --check-aux-params off-circuit validation (both the
+        # matching and mismatched cases), which the full test above does not cover.
+        run:  RUST_MIN_STACK=67108864 cargo test check_aux_params_off_circuit_validation --release -- --nocapture
 
   mersenne_tests:
     name: mersenne_tests

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -85,8 +85,11 @@ impl BinaryCommitment {
     /// 2. the unrolled-recursion verifier,
     /// 3. the unified-recursion verifier.
     ///
-    /// `aux_params` is the Blake2s chain hash computed over the layer
-    /// `end_params` (matches `UnrolledProgramProof::recursion_chain_hash`).
+    /// `aux_params` is the Blake2s recursion-chain hash folded over the layer
+    /// `end_params` in order (base -> unrolled -> unified). This is the binary
+    /// chain commitment the base program exposes in its final registers 18..=25;
+    /// it is NOT the proof's `recursion_chain_hash`, which is the prover's
+    /// internal recursion-layer chain and sits one fold short of `aux_params`.
     pub fn from_binaries(
         base_bin: &[u8],
         base_text: &[u8],

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -207,22 +207,20 @@ impl RiscWrapperWitness {
             pow_challenge,
         } = full_proof;
 
-        dbg!(binary_commitment);
-        dbg!(register_final_values);
-
         // TODO: check final_pc
-        use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
 
-        assert!(recursion_chain_preimage.is_some());
-        let mut result_hasher = Blake2sBufferingTranscript::new();
-        result_hasher.absorb(&recursion_chain_preimage.unwrap());
-
-        assert!(recursion_chain_hash.is_some());
-        assert_eq!(
-            recursion_chain_hash.unwrap(),
-            result_hasher.finalize_reset().0
-        );
         if check_aux_params {
+            use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
+
+            assert!(recursion_chain_preimage.is_some());
+            let mut result_hasher = Blake2sBufferingTranscript::new();
+            result_hasher.absorb(&recursion_chain_preimage.unwrap());
+
+            assert!(recursion_chain_hash.is_some());
+            assert_eq!(
+                recursion_chain_hash.unwrap(),
+                result_hasher.finalize_reset().0
+            );
             assert_eq!(recursion_chain_hash.unwrap(), binary_commitment.aux_params);
         }
 

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -76,45 +76,115 @@ pub struct RiscWrapperWitness {
 #[derive(Clone, Copy, Debug)]
 pub struct BinaryCommitment {
     pub end_params: [u32; 8],
-    // We propagate aux_params to subsequent layers
-    // instead of comparing it against the constant at this stage
-    // pub aux_params: [u32; 8],
+    pub aux_params: [u32; 8],
 }
 
 impl BinaryCommitment {
-    pub fn from_default_binary() -> Self {
-        // We expect to verify an unified_reduced_machine
+    /// Build from all three layer binaries explicitly:
+    /// 1. the base program (e.g. zksync_os app),
+    /// 2. the unrolled-recursion verifier,
+    /// 3. the unified-recursion verifier.
+    ///
+    /// `aux_params` is the Blake2s chain hash computed over the layer
+    /// `end_params` (matches `UnrolledProgramProof::recursion_chain_hash`).
+    pub fn from_binaries(
+        base_bin: &[u8],
+        base_text: &[u8],
+        unrolled_bin: &[u8],
+        unrolled_text: &[u8],
+        unified_bin: &[u8],
+        unified_text: &[u8],
+    ) -> Self {
+        use execution_utils::unified_circuit::compute_unified_setup_for_machine_configuration;
+        use execution_utils::unrolled::{
+            UnrolledProgramSetup, compute_setup_for_machine_configuration,
+        };
+        use risc_verifier::prover::riscv_transpiler::cycle::{
+            IMStandardIsaConfigWithUnsignedMulDiv, IWithoutByteAccessIsaConfigWithDelegation,
+        };
 
-        let security_model = crate::active_security::ACTIVE_SECURITY_MODEL;
-        Self::from_binary(
-            execution_utils::verifier_binaries::recursion_artifact(
-                security_model,
-                RecursionLayer::Unified,
-                RecursionArtifact::Bin,
-            ),
-            execution_utils::verifier_binaries::recursion_artifact(
-                security_model,
-                RecursionLayer::Unified,
-                RecursionArtifact::Txt,
-            ),
-        )
+        fn padded(bytes: &[u8]) -> Vec<u8> {
+            let mut v = bytes.to_vec();
+            setups::pad_bytecode_bytes_for_proving(&mut v);
+            v
+        }
+
+        let padded_base_bin = padded(base_bin);
+        let padded_base_text = padded(base_text);
+        let padded_unrolled_bin = padded(unrolled_bin);
+        let padded_unrolled_text = padded(unrolled_text);
+        let padded_unified_bin = padded(unified_bin);
+        let padded_unified_text = padded(unified_text);
+
+        let base_setup = compute_setup_for_machine_configuration::<
+            IMStandardIsaConfigWithUnsignedMulDiv,
+        >(&padded_base_bin, &padded_base_text);
+        let unrolled_setup = compute_setup_for_machine_configuration::<
+            IWithoutByteAccessIsaConfigWithDelegation,
+        >(&padded_unrolled_bin, &padded_unrolled_text);
+        let unified_setup = compute_unified_setup_for_machine_configuration::<
+            IWithoutByteAccessIsaConfigWithDelegation,
+        >(&padded_unified_bin, &padded_unified_text);
+
+        let (h1, p1) = UnrolledProgramSetup::begin_recursion_chain(&base_setup.end_params);
+        let (h2, p2) =
+            UnrolledProgramSetup::continue_recursion_chain(&unrolled_setup.end_params, &h1, &p1);
+        let (aux_params, _) =
+            UnrolledProgramSetup::continue_recursion_chain(&unified_setup.end_params, &h2, &p2);
+
+        Self {
+            end_params: unified_setup.end_params,
+            aux_params,
+        }
     }
 
-    pub fn from_binary(binary: &[u8], text: &[u8]) -> Self {
+    /// Build from the base program only; pulls the unrolled / unified
+    /// verifier binaries from `execution_utils::verifier_binaries`.
+    pub fn from_base_binary(base_bin: &[u8], base_text: &[u8]) -> Self {
+        let security = crate::active_security::ACTIVE_SECURITY_MODEL;
+        let load = |layer, artifact| {
+            execution_utils::verifier_binaries::recursion_artifact(security, layer, artifact)
+        };
+        Self::from_binaries(
+            base_bin,
+            base_text,
+            load(RecursionLayer::Unrolled, RecursionArtifact::Bin),
+            load(RecursionLayer::Unrolled, RecursionArtifact::Txt),
+            load(RecursionLayer::Unified, RecursionArtifact::Bin),
+            load(RecursionLayer::Unified, RecursionArtifact::Txt),
+        )
+    }
+}
+
+impl Default for BinaryCommitment {
+    /// `end_params` from the default unified-recursion verifier binary, with a
+    /// zero `aux_params`. Use when `check_aux_params` is disabled — the base
+    /// program bin/text is then unnecessary (`aux_params` is never consumed).
+    fn default() -> Self {
         use execution_utils::unified_circuit::compute_unified_setup_for_machine_configuration;
         use risc_verifier::prover::riscv_transpiler::cycle::IWithoutByteAccessIsaConfigWithDelegation;
 
-        let mut padded_binary = binary.to_vec();
-        setups::pad_bytecode_bytes_for_proving(&mut padded_binary);
-        let mut padded_text = text.to_vec();
-        setups::pad_bytecode_bytes_for_proving(&mut padded_text);
+        let security = crate::active_security::ACTIVE_SECURITY_MODEL;
+        let load = |artifact| {
+            execution_utils::verifier_binaries::recursion_artifact(
+                security,
+                RecursionLayer::Unified,
+                artifact,
+            )
+        };
 
-        let setup = compute_unified_setup_for_machine_configuration::<
+        let mut unified_bin = load(RecursionArtifact::Bin).to_vec();
+        setups::pad_bytecode_bytes_for_proving(&mut unified_bin);
+        let mut unified_text = load(RecursionArtifact::Txt).to_vec();
+        setups::pad_bytecode_bytes_for_proving(&mut unified_text);
+
+        let unified_setup = compute_unified_setup_for_machine_configuration::<
             IWithoutByteAccessIsaConfigWithDelegation,
-        >(&padded_binary, &padded_text);
+        >(&unified_bin, &unified_text);
 
         Self {
-            end_params: setup.end_params,
+            end_params: unified_setup.end_params,
+            aux_params: [0u32; 8],
         }
     }
 }
@@ -122,7 +192,8 @@ impl BinaryCommitment {
 impl RiscWrapperWitness {
     pub fn from_full_proof(
         full_proof: UnrolledProgramProof,
-        _binary_commitment: &BinaryCommitment,
+        binary_commitment: &BinaryCommitment,
+        check_aux_params: bool,
     ) -> Self {
         let UnrolledProgramProof {
             final_pc,
@@ -131,23 +202,29 @@ impl RiscWrapperWitness {
             inits_and_teardowns_proofs,
             delegation_proofs,
             register_final_values,
-            recursion_chain_preimage: _,
-            recursion_chain_hash: _,
+            recursion_chain_preimage,
+            recursion_chain_hash,
             pow_challenge,
         } = full_proof;
 
-        // TODO: check final_pc, recursion_chain_preimage, recursion_chain_hash
+        dbg!(binary_commitment);
+        dbg!(register_final_values);
 
-        // assert!(recursion_chain_preimage.is_some());
-        // let mut result_hasher = Blake2sBufferingTranscript::new();
-        // result_hasher.absorb(&recursion_chain_preimage.unwrap());
+        // TODO: check final_pc
+        use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
 
-        // assert!(recursion_chain_hash.is_some());
-        // assert_eq!(
-        //     recursion_chain_hash.unwrap(),
-        //     result_hasher.finalize_reset().0
-        // );
-        // assert_eq!(recursion_chain_hash.unwrap(), binary_commitment.aux_params);
+        assert!(recursion_chain_preimage.is_some());
+        let mut result_hasher = Blake2sBufferingTranscript::new();
+        result_hasher.absorb(&recursion_chain_preimage.unwrap());
+
+        assert!(recursion_chain_hash.is_some());
+        assert_eq!(
+            recursion_chain_hash.unwrap(),
+            result_hasher.finalize_reset().0
+        );
+        if check_aux_params {
+            assert_eq!(recursion_chain_hash.unwrap(), binary_commitment.aux_params);
+        }
 
         let (final_timestamp_low, final_timestamp_high) =
             risc_verifier::prover::cs::definitions::split_timestamp(final_timestamp);
@@ -208,6 +285,7 @@ impl RiscWrapperWitness {
 pub struct RiscWrapperCircuit<F: SmallField, V: CircuitLeafInclusionVerifier<F>> {
     pub witness: Option<RiscWrapperWitness>,
     pub binary_commitment: BinaryCommitment,
+    pub check_aux_params: bool,
     _phantom: std::marker::PhantomData<(F, V)>,
 }
 
@@ -321,6 +399,7 @@ impl<F: SmallField, V: CircuitLeafInclusionVerifier<F>> RiscWrapperCircuit<F, V>
         witness: Option<RiscWrapperWitness>,
         verify_inner_proof: bool,
         binary_commitment: BinaryCommitment,
+        check_aux_params: bool,
     ) -> Self {
         if verify_inner_proof {
             if let Some(witness) = &witness {
@@ -338,6 +417,7 @@ impl<F: SmallField, V: CircuitLeafInclusionVerifier<F>> RiscWrapperCircuit<F, V>
         Self {
             witness,
             binary_commitment,
+            check_aux_params,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -480,7 +560,12 @@ impl<F: SmallField, V: CircuitLeafInclusionVerifier<F>> RiscWrapperCircuit<F, V>
             &self.binary_commitment,
         );
 
-        prepare_and_allocate_public_inputs(cs, final_registers_state);
+        prepare_and_allocate_public_inputs(
+            cs,
+            final_registers_state,
+            self.check_aux_params,
+            &self.binary_commitment,
+        );
     }
 }
 
@@ -997,6 +1082,8 @@ pub(crate) fn check_proof_state<F: SmallField, CS: ConstraintSystem<F>>(
 fn prepare_and_allocate_public_inputs<F: SmallField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     final_registers_state: [UInt32<F>; NUM_REGISTERS * 3],
+    check_aux_params: bool,
+    binary_commitment: &BinaryCommitment,
 ) {
     // We hash needed data for the L1 verifier
     // registers 10-17 - those are the output of the base program
@@ -1010,10 +1097,26 @@ fn prepare_and_allocate_public_inputs<F: SmallField, CS: ConstraintSystem<F>>(
         .collect();
 
     use boojum::gadgets::keccak256;
+    // Always run keccak so we don't need to configure gates based on check_aux_params flag
     let input_keccak_hash = keccak256::keccak256(cs, &flattened_public_input);
+
+    let public_input_source: Vec<_> = if check_aux_params {
+        // Pack registers 10..18 directly (no keccak)
+        // In the end 28 of 32 bytes are consumed
+        // This is intentional, we assume these registers to contain a keccak hash
+        final_registers_state
+            .chunks(3)
+            .skip(10)
+            .take(8)
+            .flat_map(|chunk| chunk[0].decompose_into_bytes(cs))
+            .collect()
+    } else {
+        input_keccak_hash.to_vec()
+    };
+
     let take_by = F::CAPACITY_BITS / 8;
 
-    for chunk in input_keccak_hash
+    for chunk in public_input_source
         .chunks_exact(take_by)
         .take(NUM_RISC_WRAPPER_PUBLIC_INPUTS)
     {
@@ -1026,6 +1129,16 @@ fn prepare_and_allocate_public_inputs<F: SmallField, CS: ConstraintSystem<F>>(
         use boojum::cs::gates::PublicInputGate;
         let gate = PublicInputGate::new(as_num.get_variable());
         gate.add_to_cs(cs);
+    }
+
+    if check_aux_params {
+        // Constrain registers 18..26 (8 values) to equal the aux_params constant
+        // baked into the binary commitment. Mirrors the end_params check above.
+        for i in 0..8 {
+            let expected = UInt32::allocate_constant(cs, binary_commitment.aux_params[i]);
+            let actual = final_registers_state[(18 + i) * 3];
+            Num::enforce_equal(cs, &expected.into_num(), &actual.into_num());
+        }
     }
 }
 

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -194,7 +194,7 @@ impl RiscWrapperWitness {
         full_proof: UnrolledProgramProof,
         binary_commitment: &BinaryCommitment,
         check_aux_params: bool,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let UnrolledProgramProof {
             final_pc,
             final_timestamp,
@@ -212,16 +212,27 @@ impl RiscWrapperWitness {
         if check_aux_params {
             use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
 
-            assert!(recursion_chain_preimage.is_some());
+            let recursion_chain_preimage = recursion_chain_preimage.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "proof is missing recursion_chain_preimage, required with --check-aux-params"
+                )
+            })?;
             let mut result_hasher = Blake2sBufferingTranscript::new();
-            result_hasher.absorb(&recursion_chain_preimage.unwrap());
+            result_hasher.absorb(&recursion_chain_preimage);
 
-            assert!(recursion_chain_hash.is_some());
-            assert_eq!(
-                recursion_chain_hash.unwrap(),
-                result_hasher.finalize_reset().0
+            let recursion_chain_hash = recursion_chain_hash.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "proof is missing recursion_chain_hash, required with --check-aux-params"
+                )
+            })?;
+            anyhow::ensure!(
+                recursion_chain_hash == result_hasher.finalize_reset().0,
+                "recursion_chain_hash does not match the hash of recursion_chain_preimage"
             );
-            assert_eq!(recursion_chain_hash.unwrap(), binary_commitment.aux_params);
+            anyhow::ensure!(
+                recursion_chain_hash == binary_commitment.aux_params,
+                "recursion_chain_hash does not match the binary commitment's aux_params"
+            );
         }
 
         let (final_timestamp_low, final_timestamp_high) =
@@ -269,14 +280,14 @@ impl RiscWrapperWitness {
         };
         assert!(dp_iter.next().is_none(), "Too many delegation proofs");
 
-        Self {
+        Ok(Self {
             final_pc,
             final_timestamp: [final_timestamp_low, final_timestamp_high],
             final_registers_state: final_registers_state.try_into().unwrap(),
             unified_proofs,
             blake_proof,
             pow_challenge,
-        }
+        })
     }
 }
 

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -1095,17 +1095,23 @@ fn prepare_and_allocate_public_inputs<F: SmallField, CS: ConstraintSystem<F>>(
         .collect();
 
     use boojum::gadgets::keccak256;
-    // Always run keccak so we don't need to configure gates based on check_aux_params flag
+    // Computed unconditionally: the hashed path below consumes it. In the
+    // `check_aux_params` branch the result is discarded, but keccak is still run so
+    // the keccak gates/tables stay present in both modes, keeping the circuit
+    // skeleton uniform. Skipping it in check mode is a possible future optimization
+    // (it would change the check-mode VK).
     let input_keccak_hash = keccak256::keccak256(cs, &flattened_public_input);
 
     let public_input_source: Vec<_> = if check_aux_params {
-        // Pack registers 10..18 directly (no keccak)
-        // In the end 28 of 32 bytes are consumed
-        // This is intentional, we assume these registers to contain a keccak hash
+        // Pack registers 10..=16 (7 registers = 28 bytes) directly as the public
+        // input, bypassing keccak. The loop below consumes exactly
+        // NUM_RISC_WRAPPER_PUBLIC_INPUTS * take_by = 4 * 7 = 28 bytes, matching the
+        // 28-byte truncation the hashed path applies to the 32-byte keccak digest.
+        // We assume the base program has placed a keccak hash in these registers.
         final_registers_state
             .chunks(3)
             .skip(10)
-            .take(8)
+            .take(7)
             .flat_map(|chunk| chunk[0].decompose_into_bytes(cs))
             .collect()
     } else {

--- a/wrapper/src/circuits/risc_wrapper.rs
+++ b/wrapper/src/circuits/risc_wrapper.rs
@@ -202,37 +202,38 @@ impl RiscWrapperWitness {
             inits_and_teardowns_proofs,
             delegation_proofs,
             register_final_values,
-            recursion_chain_preimage,
-            recursion_chain_hash,
+            recursion_chain_preimage: _,
+            recursion_chain_hash: _,
             pow_challenge,
         } = full_proof;
 
         // TODO: check final_pc
 
         if check_aux_params {
-            use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
-
-            let recursion_chain_preimage = recursion_chain_preimage.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "proof is missing recursion_chain_preimage, required with --check-aux-params"
-                )
-            })?;
-            let mut result_hasher = Blake2sBufferingTranscript::new();
-            result_hasher.absorb(&recursion_chain_preimage);
-
-            let recursion_chain_hash = recursion_chain_hash.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "proof is missing recursion_chain_hash, required with --check-aux-params"
-                )
-            })?;
-            anyhow::ensure!(
-                recursion_chain_hash == result_hasher.finalize_reset().0,
-                "recursion_chain_hash does not match the hash of recursion_chain_preimage"
-            );
-            anyhow::ensure!(
-                recursion_chain_hash == binary_commitment.aux_params,
-                "recursion_chain_hash does not match the binary commitment's aux_params"
-            );
+            // Off-circuit mirror of the in-circuit aux_params constraint (see
+            // `prepare_and_allocate_public_inputs`, which enforces registers
+            // 18..=25 == aux_params). Checking it here rejects a mismatched binary
+            // commitment up front with a clear error instead of producing an
+            // unsatisfiable circuit at proving time.
+            //
+            // The program exposes the binary chain commitment in its final registers
+            // 18..=25. Note this is NOT the proof's `recursion_chain_hash`: that field
+            // is the prover's internal recursion-layer chain, which sits one fold short
+            // of `aux_params` whenever the top unified-recursion layer converges in a
+            // single iteration, so comparing against it would spuriously reject valid
+            // proofs.
+            for i in 0..8 {
+                let actual = register_final_values[18 + i].value;
+                let expected = binary_commitment.aux_params[i];
+                anyhow::ensure!(
+                    actual == expected,
+                    "register {} (0x{:08x}) does not match binary commitment aux_params[{}] (0x{:08x})",
+                    18 + i,
+                    actual,
+                    i,
+                    expected,
+                );
+            }
         }
 
         let (final_timestamp_low, final_timestamp_high) =

--- a/wrapper/src/gpu/risc_wrapper.rs
+++ b/wrapper/src/gpu/risc_wrapper.rs
@@ -27,6 +27,7 @@ type GL = GoldilocksField;
 pub fn get_risc_wrapper_setup(
     worker: &Worker,
     binary_commitment: BinaryCommitment,
+    check_aux_params: bool,
 ) -> (
     GpuSetup<RiscWrapperTreeHasher>,
     RiscWrapperVK,
@@ -34,7 +35,7 @@ pub fn get_risc_wrapper_setup(
 ) {
     let start = std::time::Instant::now();
 
-    let circuit = RiscWrapper::new(None, false, binary_commitment);
+    let circuit = RiscWrapper::new(None, false, binary_commitment, check_aux_params);
 
     let geometry = RiscWrapper::geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
@@ -87,9 +88,15 @@ pub fn prove_risc_wrapper(
     gpu_vk: &RiscWrapperVK,
     worker: &Worker,
     binary_commitment: BinaryCommitment,
+    check_aux_params: bool,
 ) -> RiscWrapperProof {
     let start = std::time::Instant::now();
-    let circuit = RiscWrapper::new(Some(risc_wrapper_witness), true, binary_commitment);
+    let circuit = RiscWrapper::new(
+        Some(risc_wrapper_witness),
+        true,
+        binary_commitment,
+        check_aux_params,
+    );
 
     let geometry = RiscWrapper::geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();

--- a/wrapper/src/interface/cmd.rs
+++ b/wrapper/src/interface/cmd.rs
@@ -49,6 +49,7 @@ pub fn cmd_prove_all(
     trusted_setup: Option<PathBuf>,
     use_zk: bool,
     save_intermediates: bool,
+    check_aux_params: bool,
     threads: Option<usize>,
 ) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
@@ -59,6 +60,7 @@ pub fn cmd_prove_all(
         text,
         trusted_setup,
         threads,
+        check_aux_params,
         risc_wrapper_vk: None,
         compression_vk: None,
         snark_vk: None,
@@ -115,6 +117,7 @@ pub fn cmd_prove_risc_wrapper(
     bin: Option<PathBuf>,
     text: Option<PathBuf>,
     output_dir: PathBuf,
+    check_aux_params: bool,
     threads: Option<usize>,
 ) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
@@ -124,6 +127,7 @@ pub fn cmd_prove_risc_wrapper(
         text,
         trusted_setup: None,
         threads,
+        check_aux_params,
         risc_wrapper_vk: None,
         compression_vk: None,
         snark_vk: None,
@@ -149,6 +153,7 @@ pub fn cmd_prove_compression(
     bin: Option<PathBuf>,
     text: Option<PathBuf>,
     output_dir: PathBuf,
+    check_aux_params: bool,
     threads: Option<usize>,
 ) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
@@ -162,6 +167,7 @@ pub fn cmd_prove_compression(
         text,
         trusted_setup: None,
         threads,
+        check_aux_params,
         risc_wrapper_vk,
         compression_vk: None,
         snark_vk: None,
@@ -189,6 +195,7 @@ pub fn cmd_prove_snark(
     output_dir: PathBuf,
     trusted_setup: Option<PathBuf>,
     use_zk: bool,
+    check_aux_params: bool,
     threads: Option<usize>,
 ) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
@@ -202,6 +209,7 @@ pub fn cmd_prove_snark(
         text,
         trusted_setup,
         threads,
+        check_aux_params,
         risc_wrapper_vk: None,
         compression_vk,
         snark_vk: None,
@@ -226,6 +234,7 @@ pub fn cmd_generate_vk(
     bin: Option<PathBuf>,
     text: Option<PathBuf>,
     trusted_setup: Option<PathBuf>,
+    check_aux_params: bool,
     threads: Option<usize>,
 ) -> anyhow::Result<()> {
     ensure_output_dir(&output_dir)?;
@@ -234,6 +243,7 @@ pub fn cmd_generate_vk(
         text,
         trusted_setup,
         threads,
+        check_aux_params,
         risc_wrapper_vk: None,
         compression_vk: None,
         snark_vk: None,
@@ -259,6 +269,27 @@ pub fn cmd_generate_vk(
 
     let vk_hash = calculate_verification_key_hash(wrapper.snark_vk()?.clone());
     tracing::info!("SNARK VK hash: {vk_hash:?}");
+
+    Ok(())
+}
+
+pub fn cmd_compute_aux_params(
+    bin: PathBuf,
+    text: PathBuf,
+    output: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let binary = std::fs::read(&bin)
+        .with_context(|| format!("while reading the binary at {}", bin.display()))?;
+    let text_data = std::fs::read(&text)
+        .with_context(|| format!("while reading the text section at {}", text.display()))?;
+
+    let commitment = crate::circuits::BinaryCommitment::from_base_binary(&binary, &text_data);
+    tracing::info!("aux_params: {:?}", commitment.aux_params);
+
+    if let Some(out) = output {
+        serialize_to_file(&commitment.aux_params, &out.to_string_lossy())?;
+        tracing::info!("Wrote aux_params to {}", out.display());
+    }
 
     Ok(())
 }

--- a/wrapper/src/interface/mod.rs
+++ b/wrapper/src/interface/mod.rs
@@ -2,6 +2,6 @@ mod cmd;
 mod utils;
 
 pub use self::cmd::{
-    VerifyStage, cmd_generate_vk, cmd_prove_all, cmd_prove_compression, cmd_prove_risc_wrapper,
-    cmd_prove_snark, cmd_verify, cmd_vk_hash,
+    VerifyStage, cmd_compute_aux_params, cmd_generate_vk, cmd_prove_all, cmd_prove_compression,
+    cmd_prove_risc_wrapper, cmd_prove_snark, cmd_verify, cmd_vk_hash,
 };

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -145,6 +145,7 @@ use proof_compression::serialization::PlonkSnarkVerifierCircuitDeviceSetupWrappe
 pub fn get_risc_wrapper_setup(
     worker: &Worker,
     binary_commitment: BinaryCommitment,
+    check_aux_params: bool,
 ) -> (
     FinalizationHintsForProver,
     SetupBaseStorage<GL>,
@@ -154,7 +155,7 @@ pub fn get_risc_wrapper_setup(
     DenseVariablesCopyHint,
     DenseWitnessCopyHint,
 ) {
-    let circuit = RiscWrapper::new(None, false, binary_commitment);
+    let circuit = RiscWrapper::new(None, false, binary_commitment, check_aux_params);
 
     let geometry = RiscWrapper::geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
@@ -205,8 +206,14 @@ pub fn prove_risc_wrapper(
     witness_hints: &DenseWitnessCopyHint,
     worker: &Worker,
     binary_commitment: BinaryCommitment,
+    check_aux_params: bool,
 ) -> RiscWrapperProof {
-    let circuit = RiscWrapper::new(Some(risc_wrapper_witness), true, binary_commitment);
+    let circuit = RiscWrapper::new(
+        Some(risc_wrapper_witness),
+        true,
+        binary_commitment,
+        check_aux_params,
+    );
 
     let geometry = RiscWrapper::geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();

--- a/wrapper/src/main.rs
+++ b/wrapper/src/main.rs
@@ -96,12 +96,14 @@ enum Commands {
         #[arg(long)]
         risc_wrapper_vk: Option<PathBuf>,
 
-        /// Path to the base program .bin file (required with --check-aux-params)
-        #[arg(long, requires = "text", required_if_eq("check_aux_params", "true"))]
+        /// Path to the base program .bin file (needed with --check-aux-params
+        /// unless a saved --risc-wrapper-vk is supplied)
+        #[arg(long, requires = "text")]
         bin: Option<PathBuf>,
 
-        /// Path to the base program .text file (required with --check-aux-params)
-        #[arg(long, requires = "bin", required_if_eq("check_aux_params", "true"))]
+        /// Path to the base program .text file (needed with --check-aux-params
+        /// unless a saved --risc-wrapper-vk is supplied)
+        #[arg(long, requires = "bin")]
         text: Option<PathBuf>,
 
         /// Output directory
@@ -123,12 +125,14 @@ enum Commands {
         #[arg(long)]
         compression_vk: Option<PathBuf>,
 
-        /// Path to the base program .bin file (required with --check-aux-params)
-        #[arg(long, requires = "text", required_if_eq("check_aux_params", "true"))]
+        /// Path to the base program .bin file (needed with --check-aux-params
+        /// unless a saved --compression-vk is supplied)
+        #[arg(long, requires = "text")]
         bin: Option<PathBuf>,
 
-        /// Path to the base program .text file (required with --check-aux-params)
-        #[arg(long, requires = "bin", required_if_eq("check_aux_params", "true"))]
+        /// Path to the base program .text file (needed with --check-aux-params
+        /// unless a saved --compression-vk is supplied)
+        #[arg(long, requires = "bin")]
         text: Option<PathBuf>,
 
         /// Output directory

--- a/wrapper/src/main.rs
+++ b/wrapper/src/main.rs
@@ -31,11 +31,11 @@ enum Commands {
         proof: PathBuf,
 
         /// Path to the base program .bin file (required with --check-aux-params)
-        #[arg(long, requires = "text")]
+        #[arg(long, requires = "text", required_if_eq("check_aux_params", "true"))]
         bin: Option<PathBuf>,
 
         /// Path to the base program .text file (required with --check-aux-params)
-        #[arg(long, requires = "bin")]
+        #[arg(long, requires = "bin", required_if_eq("check_aux_params", "true"))]
         text: Option<PathBuf>,
 
         /// Output directory for proof and VK files
@@ -68,11 +68,11 @@ enum Commands {
         proof: PathBuf,
 
         /// Path to the base program .bin file (required with --check-aux-params)
-        #[arg(long, requires = "text")]
+        #[arg(long, requires = "text", required_if_eq("check_aux_params", "true"))]
         bin: Option<PathBuf>,
 
         /// Path to the base program .text file (required with --check-aux-params)
-        #[arg(long, requires = "bin")]
+        #[arg(long, requires = "bin", required_if_eq("check_aux_params", "true"))]
         text: Option<PathBuf>,
 
         /// Output directory
@@ -97,11 +97,11 @@ enum Commands {
         risc_wrapper_vk: Option<PathBuf>,
 
         /// Path to the base program .bin file (required with --check-aux-params)
-        #[arg(long, requires = "text")]
+        #[arg(long, requires = "text", required_if_eq("check_aux_params", "true"))]
         bin: Option<PathBuf>,
 
         /// Path to the base program .text file (required with --check-aux-params)
-        #[arg(long, requires = "bin")]
+        #[arg(long, requires = "bin", required_if_eq("check_aux_params", "true"))]
         text: Option<PathBuf>,
 
         /// Output directory
@@ -124,11 +124,11 @@ enum Commands {
         compression_vk: Option<PathBuf>,
 
         /// Path to the base program .bin file (required with --check-aux-params)
-        #[arg(long, requires = "text")]
+        #[arg(long, requires = "text", required_if_eq("check_aux_params", "true"))]
         bin: Option<PathBuf>,
 
         /// Path to the base program .text file (required with --check-aux-params)
-        #[arg(long, requires = "bin")]
+        #[arg(long, requires = "bin", required_if_eq("check_aux_params", "true"))]
         text: Option<PathBuf>,
 
         /// Output directory
@@ -155,11 +155,11 @@ enum Commands {
         output_dir: PathBuf,
 
         /// Path to the base program .bin file (required with --check-aux-params)
-        #[arg(long, requires = "text")]
+        #[arg(long, requires = "text", required_if_eq("check_aux_params", "true"))]
         bin: Option<PathBuf>,
 
         /// Path to the base program .text file (required with --check-aux-params)
-        #[arg(long, requires = "bin")]
+        #[arg(long, requires = "bin", required_if_eq("check_aux_params", "true"))]
         text: Option<PathBuf>,
 
         /// Path to trusted setup (CRS) file. If omitted, uses fake crs_42.

--- a/wrapper/src/main.rs
+++ b/wrapper/src/main.rs
@@ -54,9 +54,9 @@ enum Commands {
         #[arg(long)]
         save_intermediates: bool,
 
-        /// Pack registers 10..18 directly as public inputs and constrain
-        /// registers 18..26 to `BinaryCommitment::aux_params` (instead of
-        /// hashing registers 10..26 into the public input).
+        /// Pack registers 10..=16 directly as public inputs and constrain
+        /// registers 18..=25 to `BinaryCommitment::aux_params` (instead of
+        /// hashing registers 10..=25 into the public input).
         #[arg(long)]
         check_aux_params: bool,
     },
@@ -79,9 +79,9 @@ enum Commands {
         #[arg(short, long)]
         output_dir: PathBuf,
 
-        /// Pack registers 10..18 directly as public inputs and constrain
-        /// registers 18..26 to `BinaryCommitment::aux_params` (instead of
-        /// hashing registers 10..26 into the public input).
+        /// Pack registers 10..=16 directly as public inputs and constrain
+        /// registers 18..=25 to `BinaryCommitment::aux_params` (instead of
+        /// hashing registers 10..=25 into the public input).
         #[arg(long)]
         check_aux_params: bool,
     },
@@ -170,8 +170,8 @@ enum Commands {
         #[arg(long)]
         trusted_setup: Option<PathBuf>,
 
-        /// Pack registers 10..18 directly as public inputs and constrain
-        /// registers 18..26 to `BinaryCommitment::aux_params`.
+        /// Pack registers 10..=16 directly as public inputs and constrain
+        /// registers 18..=25 to `BinaryCommitment::aux_params`.
         #[arg(long)]
         check_aux_params: bool,
     },

--- a/wrapper/src/main.rs
+++ b/wrapper/src/main.rs
@@ -30,11 +30,11 @@ enum Commands {
         #[arg(long)]
         proof: PathBuf,
 
-        /// Path to the RISC-V .bin file (omit to use default recursion verifier)
+        /// Path to the base program .bin file (required with --check-aux-params)
         #[arg(long, requires = "text")]
         bin: Option<PathBuf>,
 
-        /// Path to the RISC-V .text file (omit to use default recursion verifier)
+        /// Path to the base program .text file (required with --check-aux-params)
         #[arg(long, requires = "bin")]
         text: Option<PathBuf>,
 
@@ -53,6 +53,12 @@ enum Commands {
         /// Save intermediate proofs (risc wrapper, compression) alongside final SNARK
         #[arg(long)]
         save_intermediates: bool,
+
+        /// Pack registers 10..18 directly as public inputs and constrain
+        /// registers 18..26 to `BinaryCommitment::aux_params` (instead of
+        /// hashing registers 10..26 into the public input).
+        #[arg(long)]
+        check_aux_params: bool,
     },
 
     /// Phase 1: Wrap FRI proof into a boojum STARK proof
@@ -61,17 +67,23 @@ enum Commands {
         #[arg(long)]
         proof: PathBuf,
 
-        /// Path to the RISC-V .bin file (omit to use default recursion verifier)
+        /// Path to the base program .bin file (required with --check-aux-params)
         #[arg(long, requires = "text")]
         bin: Option<PathBuf>,
 
-        /// Path to the RISC-V .text file (omit to use default recursion verifier)
+        /// Path to the base program .text file (required with --check-aux-params)
         #[arg(long, requires = "bin")]
         text: Option<PathBuf>,
 
         /// Output directory
         #[arg(short, long)]
         output_dir: PathBuf,
+
+        /// Pack registers 10..18 directly as public inputs and constrain
+        /// registers 18..26 to `BinaryCommitment::aux_params` (instead of
+        /// hashing registers 10..26 into the public input).
+        #[arg(long)]
+        check_aux_params: bool,
     },
 
     /// Phase 2: Compress a STARK wrapper proof (Poseidon2-based re-hashing)
@@ -84,17 +96,21 @@ enum Commands {
         #[arg(long)]
         risc_wrapper_vk: Option<PathBuf>,
 
-        /// Path to the RISC-V .bin file (omit to use default recursion verifier)
+        /// Path to the base program .bin file (required with --check-aux-params)
         #[arg(long, requires = "text")]
         bin: Option<PathBuf>,
 
-        /// Path to the RISC-V .text file (omit to use default recursion verifier)
+        /// Path to the base program .text file (required with --check-aux-params)
         #[arg(long, requires = "bin")]
         text: Option<PathBuf>,
 
         /// Output directory
         #[arg(short, long)]
         output_dir: PathBuf,
+
+        /// Must match the value used to produce the phase-1 proof / VK chain.
+        #[arg(long)]
+        check_aux_params: bool,
     },
 
     /// Phase 3: Wrap compressed STARK proof into a BN256 SNARK
@@ -107,11 +123,11 @@ enum Commands {
         #[arg(long)]
         compression_vk: Option<PathBuf>,
 
-        /// Path to the RISC-V .bin file (omit to use default recursion verifier)
+        /// Path to the base program .bin file (required with --check-aux-params)
         #[arg(long, requires = "text")]
         bin: Option<PathBuf>,
 
-        /// Path to the RISC-V .text file (omit to use default recursion verifier)
+        /// Path to the base program .text file (required with --check-aux-params)
         #[arg(long, requires = "bin")]
         text: Option<PathBuf>,
 
@@ -126,6 +142,10 @@ enum Commands {
         /// Enable zero-knowledge padding in SNARK proving
         #[arg(long)]
         use_zk: bool,
+
+        /// Must match the value used to produce the phase-1 proof / VK chain.
+        #[arg(long)]
+        check_aux_params: bool,
     },
 
     /// Generate verification keys without a proof (for deployment preparation)
@@ -134,17 +154,37 @@ enum Commands {
         #[arg(short, long)]
         output_dir: PathBuf,
 
-        /// Path to RISC-V .bin file (omit to use default recursion verifier)
+        /// Path to the base program .bin file (required with --check-aux-params)
         #[arg(long, requires = "text")]
         bin: Option<PathBuf>,
 
-        /// Path to RISC-V .text file (omit to use default recursion verifier)
+        /// Path to the base program .text file (required with --check-aux-params)
         #[arg(long, requires = "bin")]
         text: Option<PathBuf>,
 
         /// Path to trusted setup (CRS) file. If omitted, uses fake crs_42.
         #[arg(long)]
         trusted_setup: Option<PathBuf>,
+
+        /// Pack registers 10..18 directly as public inputs and constrain
+        /// registers 18..26 to `BinaryCommitment::aux_params`.
+        #[arg(long)]
+        check_aux_params: bool,
+    },
+
+    /// Compute the 3-layer recursion-chain hash (aux_params) for a base program
+    ComputeAuxParams {
+        /// Path to the base program .bin file
+        #[arg(long, requires = "text")]
+        bin: PathBuf,
+
+        /// Path to the base program .text file
+        #[arg(long, requires = "bin")]
+        text: PathBuf,
+
+        /// Optional path to write aux_params as a JSON [u32; 8] array
+        #[arg(long)]
+        output: Option<PathBuf>,
     },
 
     /// Compute the Keccak256 hash of a SNARK verification key
@@ -215,6 +255,7 @@ fn main() -> anyhow::Result<()> {
             trusted_setup,
             use_zk,
             save_intermediates,
+            check_aux_params,
         } => interface::cmd_prove_all(
             proof,
             bin,
@@ -223,6 +264,7 @@ fn main() -> anyhow::Result<()> {
             trusted_setup,
             use_zk,
             save_intermediates,
+            check_aux_params,
             cli.threads,
         ),
 
@@ -231,7 +273,15 @@ fn main() -> anyhow::Result<()> {
             bin,
             text,
             output_dir,
-        } => interface::cmd_prove_risc_wrapper(proof, bin, text, output_dir, cli.threads),
+            check_aux_params,
+        } => interface::cmd_prove_risc_wrapper(
+            proof,
+            bin,
+            text,
+            output_dir,
+            check_aux_params,
+            cli.threads,
+        ),
 
         Commands::ProveCompression {
             risc_wrapper_proof,
@@ -239,12 +289,14 @@ fn main() -> anyhow::Result<()> {
             bin,
             text,
             output_dir,
+            check_aux_params,
         } => interface::cmd_prove_compression(
             risc_wrapper_proof,
             risc_wrapper_vk,
             bin,
             text,
             output_dir,
+            check_aux_params,
             cli.threads,
         ),
 
@@ -256,6 +308,7 @@ fn main() -> anyhow::Result<()> {
             output_dir,
             trusted_setup,
             use_zk,
+            check_aux_params,
         } => interface::cmd_prove_snark(
             compression_proof,
             compression_vk,
@@ -264,6 +317,7 @@ fn main() -> anyhow::Result<()> {
             output_dir,
             trusted_setup,
             use_zk,
+            check_aux_params,
             cli.threads,
         ),
 
@@ -272,7 +326,19 @@ fn main() -> anyhow::Result<()> {
             bin,
             text,
             trusted_setup,
-        } => interface::cmd_generate_vk(output_dir, bin, text, trusted_setup, cli.threads),
+            check_aux_params,
+        } => interface::cmd_generate_vk(
+            output_dir,
+            bin,
+            text,
+            trusted_setup,
+            check_aux_params,
+            cli.threads,
+        ),
+
+        Commands::ComputeAuxParams { bin, text, output } => {
+            interface::cmd_compute_aux_params(bin, text, output)
+        }
 
         Commands::VkHash { vk } => interface::cmd_vk_hash(vk),
 

--- a/wrapper/src/tests/mod.rs
+++ b/wrapper/src/tests/mod.rs
@@ -142,3 +142,29 @@ fn convert_risc_proof_from_json() {
     let after = std::fs::metadata(path).unwrap().len();
     println!("{path}: {before} -> {after} bytes");
 }
+
+/// Manual fixture-prep utility, not a real test (makes no assertions).
+/// Strips the recursion_chain fields from the checked-in RISC_PROOF_PATH fixture
+/// and rewrites it in place. Ignored by default because it mutates tracked test
+/// data; run explicitly with `cargo test small_test -- --ignored` when you need
+/// to regenerate the fixture.
+#[test]
+#[ignore = "mutates the checked-in RISC_PROOF_PATH fixture; run manually with --ignored"]
+fn small_test() {
+    use execution_utils::unrolled::UnrolledProgramProof;
+
+    let path = RISC_PROOF_PATH;
+    let mut value: UnrolledProgramProof = deserialize_from_bin_file(path).unwrap();
+    // value.recursion_chain_preimage = Some([0; 16]);
+
+    // use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
+    // let mut result_hasher = Blake2sBufferingTranscript::new();
+    // result_hasher.absorb(&value.recursion_chain_preimage.unwrap());
+
+    // value.recursion_chain_hash = Some(result_hasher.finalize_reset().0);
+
+    value.recursion_chain_preimage = None;
+    value.recursion_chain_hash = None;
+
+    serialize_to_bin_file(&value, &path).unwrap();
+}

--- a/wrapper/src/tests/mod.rs
+++ b/wrapper/src/tests/mod.rs
@@ -142,3 +142,23 @@ fn convert_risc_proof_from_json() {
     let after = std::fs::metadata(path).unwrap().len();
     println!("{path}: {before} -> {after} bytes");
 }
+
+#[test]
+fn small_test() {
+    use execution_utils::unrolled::UnrolledProgramProof;
+
+    let path = RISC_PROOF_PATH;
+    let mut value: UnrolledProgramProof = deserialize_from_bin_file(path).unwrap();
+    // value.recursion_chain_preimage = Some([0; 16]);
+
+    // use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
+    // let mut result_hasher = Blake2sBufferingTranscript::new();
+    // result_hasher.absorb(&value.recursion_chain_preimage.unwrap());
+
+    // value.recursion_chain_hash = Some(result_hasher.finalize_reset().0);
+
+    value.recursion_chain_preimage = None;
+    value.recursion_chain_hash = None;
+
+    serialize_to_bin_file(&value, &path).unwrap();
+}

--- a/wrapper/src/tests/mod.rs
+++ b/wrapper/src/tests/mod.rs
@@ -142,23 +142,3 @@ fn convert_risc_proof_from_json() {
     let after = std::fs::metadata(path).unwrap().len();
     println!("{path}: {before} -> {after} bytes");
 }
-
-#[test]
-fn small_test() {
-    use execution_utils::unrolled::UnrolledProgramProof;
-
-    let path = RISC_PROOF_PATH;
-    let mut value: UnrolledProgramProof = deserialize_from_bin_file(path).unwrap();
-    // value.recursion_chain_preimage = Some([0; 16]);
-
-    // use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
-    // let mut result_hasher = Blake2sBufferingTranscript::new();
-    // result_hasher.absorb(&value.recursion_chain_preimage.unwrap());
-
-    // value.recursion_chain_hash = Some(result_hasher.finalize_reset().0);
-
-    value.recursion_chain_preimage = None;
-    value.recursion_chain_hash = None;
-
-    serialize_to_bin_file(&value, &path).unwrap();
-}

--- a/wrapper/src/tests/mod.rs
+++ b/wrapper/src/tests/mod.rs
@@ -142,29 +142,3 @@ fn convert_risc_proof_from_json() {
     let after = std::fs::metadata(path).unwrap().len();
     println!("{path}: {before} -> {after} bytes");
 }
-
-/// Manual fixture-prep utility, not a real test (makes no assertions).
-/// Strips the recursion_chain fields from the checked-in RISC_PROOF_PATH fixture
-/// and rewrites it in place. Ignored by default because it mutates tracked test
-/// data; run explicitly with `cargo test small_test -- --ignored` when you need
-/// to regenerate the fixture.
-#[test]
-#[ignore = "mutates the checked-in RISC_PROOF_PATH fixture; run manually with --ignored"]
-fn small_test() {
-    use execution_utils::unrolled::UnrolledProgramProof;
-
-    let path = RISC_PROOF_PATH;
-    let mut value: UnrolledProgramProof = deserialize_from_bin_file(path).unwrap();
-    // value.recursion_chain_preimage = Some([0; 16]);
-
-    // use risc_verifier::prover::transcript::Blake2sBufferingTranscript;
-    // let mut result_hasher = Blake2sBufferingTranscript::new();
-    // result_hasher.absorb(&value.recursion_chain_preimage.unwrap());
-
-    // value.recursion_chain_hash = Some(result_hasher.finalize_reset().0);
-
-    value.recursion_chain_preimage = None;
-    value.recursion_chain_hash = None;
-
-    serialize_to_bin_file(&value, &path).unwrap();
-}

--- a/wrapper/src/tests/risc_wrapper_tests.rs
+++ b/wrapper/src/tests/risc_wrapper_tests.rs
@@ -2,32 +2,50 @@ use crate::circuits::{BinaryCommitment, RiscWrapperWitness};
 
 use super::*;
 
+/// Commitment matching the checked-in `RISC_PROOF_PATH` fixture for the active
+/// security level, mirroring the (non-check) production path so the derived VK
+/// stays consistent with the checked-in fixtures.
+///
+/// - `security_80`: `risc_proof_80sb` is a proof over the `risc_app` program, so
+///   the `end_params` are derived from the checked-in program bin/text.
+/// - `security_100`: `risc_proof_100sb` is a proof over the default
+///   unified-recursion verifier binary, matching `BinaryCommitment::default()`.
+///
+/// `aux_params` is left zeroed; these callers exercise the `check_aux_params =
+/// false` path where it is never consumed.
 fn binary_commitment_for_testing() -> BinaryCommitment {
-    use std::io::Read;
+    #[cfg(feature = "security_100")]
+    {
+        BinaryCommitment::default()
+    }
+    #[cfg(feature = "security_80")]
+    {
+        use std::io::Read;
 
-    let mut binary = vec![];
-    let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
-    file.read_to_end(&mut binary).unwrap();
+        let mut binary = vec![];
+        let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
+        file.read_to_end(&mut binary).unwrap();
 
-    let mut text = vec![];
-    let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
-    file.read_to_end(&mut text).unwrap();
+        let mut text = vec![];
+        let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
+        file.read_to_end(&mut text).unwrap();
 
-    let mut padded_binary = binary.to_vec();
-    setups::pad_bytecode_bytes_for_proving(&mut padded_binary);
-    let mut padded_text = text.to_vec();
-    setups::pad_bytecode_bytes_for_proving(&mut padded_text);
+        let mut padded_binary = binary.to_vec();
+        setups::pad_bytecode_bytes_for_proving(&mut padded_binary);
+        let mut padded_text = text.to_vec();
+        setups::pad_bytecode_bytes_for_proving(&mut padded_text);
 
-    use execution_utils::unified_circuit::compute_unified_setup_for_machine_configuration;
-    use risc_verifier::prover::riscv_transpiler::cycle::IWithoutByteAccessIsaConfigWithDelegation;
+        use execution_utils::unified_circuit::compute_unified_setup_for_machine_configuration;
+        use risc_verifier::prover::riscv_transpiler::cycle::IWithoutByteAccessIsaConfigWithDelegation;
 
-    let setup = compute_unified_setup_for_machine_configuration::<
-        IWithoutByteAccessIsaConfigWithDelegation,
-    >(&padded_binary, &padded_text);
+        let setup = compute_unified_setup_for_machine_configuration::<
+            IWithoutByteAccessIsaConfigWithDelegation,
+        >(&padded_binary, &padded_text);
 
-    BinaryCommitment {
-        end_params: setup.end_params,
-        aux_params: [0; 8],
+        BinaryCommitment {
+            end_params: setup.end_params,
+            aux_params: [0; 8],
+        }
     }
 }
 
@@ -108,10 +126,11 @@ pub(crate) fn risc_wrapper_full_test() {
 
 #[test]
 pub(crate) fn risc_wrapper_setup_test() {
-    use std::io::Read;
     let worker = boojum::worker::Worker::new();
 
-    let binary_commitment = binary_commitment_for_testing();
+    // Mirror the production non-check path (`check_aux_params = false` returns
+    // `BinaryCommitment::default()`) so the checked-in VK fixture stays valid.
+    let binary_commitment = BinaryCommitment::default();
 
     let (_finalization_hint, _setup_base, _setup, vk, _setup_tree, _vars_hint, _witness_hints) =
         crate::get_risc_wrapper_setup(&worker, binary_commitment, false);
@@ -119,8 +138,99 @@ pub(crate) fn risc_wrapper_setup_test() {
     serialize_to_bin_file(&vk, RISC_WRAPPER_VK_PATH).unwrap();
 }
 
+/// Off-circuit `check_aux_params` validation in `from_full_proof`: a commitment
+/// whose `aux_params` equals the proof's final registers 18..=25 is accepted,
+/// and any mismatch is rejected up front with a clear error. This mirrors the
+/// in-circuit aux constraint and guards against comparing against the wrong
+/// value (e.g. the proof's `recursion_chain_hash`, which is one recursion fold
+/// short of `aux_params`).
+#[test]
+fn check_aux_params_off_circuit_validation() {
+    let program_proof: execution_utils::unrolled::UnrolledProgramProof =
+        deserialize_from_bin_file(RISC_PROOF_PATH).unwrap();
+
+    // The binary chain commitment the program exposes in its final registers.
+    let mut aux_params = [0u32; 8];
+    for i in 0..8 {
+        aux_params[i] = program_proof.register_final_values[18 + i].value;
+    }
+
+    let end_params = binary_commitment_for_testing().end_params;
+
+    // Positive: matching aux_params is accepted.
+    let matching = BinaryCommitment {
+        end_params,
+        aux_params,
+    };
+    RiscWrapperWitness::from_full_proof(program_proof.clone(), &matching, true)
+        .expect("matching aux_params must be accepted in check mode");
+
+    // Negative: a single flipped word is rejected.
+    let mut wrong_aux = aux_params;
+    wrong_aux[0] ^= 1;
+    let mismatched = BinaryCommitment {
+        end_params,
+        aux_params: wrong_aux,
+    };
+    let err = match RiscWrapperWitness::from_full_proof(program_proof, &mismatched, true) {
+        Ok(_) => panic!("mismatched aux_params must be rejected in check mode"),
+        Err(err) => err,
+    };
+    assert!(
+        err.to_string().contains("aux_params"),
+        "unexpected error message: {err}"
+    );
+}
+
+/// `BinaryCommitment::from_base_binary` is the core of the `compute-aux-params`
+/// subcommand: it derives `end_params` and the folded 3-layer recursion-chain
+/// `aux_params` from the base program. Smoke-test that it runs and produces a
+/// non-trivial commitment.
+///
+/// `#[ignore]`d because it computes three full recursion-layer setups (~minutes);
+/// run explicitly with `cargo test from_base_binary_computes_aux_params -- --ignored`.
+#[test]
+#[ignore]
+fn from_base_binary_computes_aux_params() {
+    use std::io::Read;
+
+    let mut binary = vec![];
+    std::fs::File::open(RISC_PROGRAM_BIN_PATH)
+        .unwrap()
+        .read_to_end(&mut binary)
+        .unwrap();
+    let mut text = vec![];
+    std::fs::File::open(RISC_PROGRAM_TEXT_PATH)
+        .unwrap()
+        .read_to_end(&mut text)
+        .unwrap();
+
+    let commitment = BinaryCommitment::from_base_binary(&binary, &text);
+
+    assert_ne!(
+        commitment.end_params, [0u32; 8],
+        "end_params must be populated"
+    );
+    assert_ne!(
+        commitment.aux_params, [0u32; 8],
+        "aux_params (recursion-chain hash) must be populated"
+    );
+}
+
 #[test]
 fn test_verifier_inner_function() {
+    run_verifier_inner_function(false);
+}
+
+/// In-circuit coverage of `--check-aux-params` mode: builds the wrapper circuit
+/// with a commitment whose `aux_params` equals the proof's final registers
+/// 18..=25 and asserts the constraint system is satisfied.
+#[test]
+fn test_verifier_inner_function_check_aux_params() {
+    run_verifier_inner_function(true);
+}
+
+fn run_verifier_inner_function(check_aux_params: bool) {
     // allocate CS
     let geometry = CSGeometry {
         num_columns_under_copy_permutation: 180,
@@ -199,40 +309,39 @@ fn test_verifier_inner_function() {
     // let mut owned_cs = builder.build(CircuitResolverOpts::new(1 << 27));
     let mut owned_cs = builder.build(1 << 27);
 
-    // add tables
-    let table = create_range_check_16_bits_table::<3, F>();
-    owned_cs.add_lookup_table::<RangeCheck16BitsTable<3>, 3>(table);
-
-    let table = create_range_check_15_bits_table::<3, F>();
-    owned_cs.add_lookup_table::<RangeCheck15BitsTable<3>, 3>(table);
-
-    let table = create_xor8_table();
-    owned_cs.add_lookup_table::<Xor8Table, 3>(table);
-
-    let table = create_byte_split_table::<F, 4>();
-    owned_cs.add_lookup_table::<ByteSplitTable<4>, 3>(table);
-
-    let table = create_byte_split_table::<F, 7>();
-    owned_cs.add_lookup_table::<ByteSplitTable<7>, 3>(table);
-
-    let table = create_byte_split_table::<F, 1>();
-    owned_cs.add_lookup_table::<ByteSplitTable<1>, 3>(table);
-
     let cs = &mut owned_cs;
 
-    let path = "testing_data/unified_proof_for_hashed_fibonacci.json";
-    // let path = "testing_data/risc_proof_80sb.json";
     let program_proof: execution_utils::unrolled::UnrolledProgramProof =
-        crate::deserialize_from_file(path).unwrap();
+        deserialize_from_bin_file(RISC_PROOF_PATH).unwrap();
 
-    let binary_commitment = binary_commitment_for_testing();
+    // Commitment matching the checked-in proof fixture for the active security
+    // level (see `binary_commitment_for_testing`).
+    let mut binary_commitment = binary_commitment_for_testing();
+    if check_aux_params {
+        // The program exposes its binary chain commitment in final registers
+        // 18..=25; bake exactly those values so both the off-circuit and
+        // in-circuit aux_params checks are satisfiable.
+        for i in 0..8 {
+            binary_commitment.aux_params[i] = program_proof.register_final_values[18 + i].value;
+        }
+    }
 
     let risc_wrapper_witness =
-        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, false).unwrap();
+        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, check_aux_params)
+            .unwrap();
 
     use crate::RiscWrapper;
 
-    let circuit = RiscWrapper::new(Some(risc_wrapper_witness), true, binary_commitment, false);
+    let circuit = RiscWrapper::new(
+        Some(risc_wrapper_witness),
+        true,
+        binary_commitment,
+        check_aux_params,
+    );
+
+    // Register the full canonical table set the circuit needs (the manual subset
+    // this test used previously was incomplete for the checked-in proof fixture).
+    circuit.add_tables(cs);
 
     circuit.synthesize_into_cs(cs);
 

--- a/wrapper/src/tests/risc_wrapper_tests.rs
+++ b/wrapper/src/tests/risc_wrapper_tests.rs
@@ -7,7 +7,7 @@ pub(crate) fn risc_wrapper_full_test() {
     use std::io::Read;
     let worker = boojum::worker::Worker::new_with_num_threads(32);
 
-    let binary_commitment = if cfg!(feature = "security_80") {
+    let binary_commitment = {
         let mut binary = vec![];
         let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
         file.read_to_end(&mut binary).unwrap();
@@ -16,12 +16,7 @@ pub(crate) fn risc_wrapper_full_test() {
         let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
         file.read_to_end(&mut text).unwrap();
 
-        // We use a prove of hashed fibonacci for testing
-        BinaryCommitment::from_binary(&binary, &text)
-    } else if cfg!(feature = "security_100") {
-        BinaryCommitment::from_default_binary()
-    } else {
-        panic!("Please specify a security level feature");
+        BinaryCommitment::from_base_binary(&binary, &text)
     };
     dbg!(binary_commitment);
 
@@ -29,7 +24,7 @@ pub(crate) fn risc_wrapper_full_test() {
         deserialize_from_bin_file(RISC_PROOF_PATH).unwrap();
 
     let risc_wrapper_witness =
-        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment);
+        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, false);
 
     #[cfg(not(feature = "gpu"))]
     let (risc_wrapper_proof, risc_wrapper_vk) = {
@@ -41,7 +36,7 @@ pub(crate) fn risc_wrapper_full_test() {
             setup_tree,
             vars_hint,
             witness_hints,
-        ) = crate::get_risc_wrapper_setup(&worker, binary_commitment.clone());
+        ) = crate::get_risc_wrapper_setup(&worker, binary_commitment.clone(), false);
 
         let risc_wrapper_proof = crate::prove_risc_wrapper(
             risc_wrapper_witness,
@@ -54,6 +49,7 @@ pub(crate) fn risc_wrapper_full_test() {
             &witness_hints,
             &worker,
             binary_commitment.clone(),
+            false,
         );
 
         let is_valid = crate::verify_risc_wrapper_proof(&risc_wrapper_proof, &risc_wrapper_vk);
@@ -66,7 +62,11 @@ pub(crate) fn risc_wrapper_full_test() {
     let (risc_wrapper_proof, risc_wrapper_vk) = {
         let _prover_context = shivini::ProverContext::create().unwrap();
         let (gpu_setup, gpu_vk, finalization_hint) =
-            crate::gpu::risc_wrapper::get_risc_wrapper_setup(&worker, binary_commitment.clone());
+            crate::gpu::risc_wrapper::get_risc_wrapper_setup(
+                &worker,
+                binary_commitment.clone(),
+                false,
+            );
 
         let risc_wrapper_proof = crate::gpu::risc_wrapper::prove_risc_wrapper(
             risc_wrapper_witness,
@@ -75,6 +75,7 @@ pub(crate) fn risc_wrapper_full_test() {
             &gpu_vk,
             &worker,
             binary_commitment.clone(),
+            false,
         );
 
         let is_valid = crate::verify_risc_wrapper_proof(&risc_wrapper_proof, &gpu_vk);
@@ -89,11 +90,20 @@ pub(crate) fn risc_wrapper_full_test() {
 
 #[test]
 pub(crate) fn risc_wrapper_setup_test() {
+    use std::io::Read;
     let worker = boojum::worker::Worker::new();
-    let binary_commitment = BinaryCommitment::from_default_binary();
+
+    let mut binary = vec![];
+    let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
+    file.read_to_end(&mut binary).unwrap();
+    let mut text = vec![];
+    let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
+    file.read_to_end(&mut text).unwrap();
+
+    let binary_commitment = BinaryCommitment::from_base_binary(&binary, &text);
 
     let (_finalization_hint, _setup_base, _setup, vk, _setup_tree, _vars_hint, _witness_hints) =
-        crate::get_risc_wrapper_setup(&worker, binary_commitment);
+        crate::get_risc_wrapper_setup(&worker, binary_commitment, false);
 
     serialize_to_bin_file(&vk, RISC_WRAPPER_VK_PATH).unwrap();
 }
@@ -203,14 +213,22 @@ fn test_verifier_inner_function() {
     // let path = "testing_data/risc_proof_80sb.json";
     let program_proof: execution_utils::unrolled::UnrolledProgramProof =
         crate::deserialize_from_file(path).unwrap();
-    let binary_commitment = BinaryCommitment::from_default_binary();
+
+    use std::io::Read;
+    let mut binary = vec![];
+    let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
+    file.read_to_end(&mut binary).unwrap();
+    let mut text = vec![];
+    let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
+    file.read_to_end(&mut text).unwrap();
+    let binary_commitment = BinaryCommitment::from_base_binary(&binary, &text);
 
     let risc_wrapper_witness =
-        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment);
+        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, false);
 
     use crate::RiscWrapper;
 
-    let circuit = RiscWrapper::new(Some(risc_wrapper_witness), true, binary_commitment);
+    let circuit = RiscWrapper::new(Some(risc_wrapper_witness), true, binary_commitment, false);
 
     circuit.synthesize_into_cs(cs);
 

--- a/wrapper/src/tests/risc_wrapper_tests.rs
+++ b/wrapper/src/tests/risc_wrapper_tests.rs
@@ -2,22 +2,40 @@ use crate::circuits::{BinaryCommitment, RiscWrapperWitness};
 
 use super::*;
 
+fn binary_commitment_for_testing() -> BinaryCommitment {
+    use std::io::Read;
+
+    let mut binary = vec![];
+    let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
+    file.read_to_end(&mut binary).unwrap();
+
+    let mut text = vec![];
+    let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
+    file.read_to_end(&mut text).unwrap();
+
+    let mut padded_binary = binary.to_vec();
+    setups::pad_bytecode_bytes_for_proving(&mut padded_binary);
+    let mut padded_text = text.to_vec();
+    setups::pad_bytecode_bytes_for_proving(&mut padded_text);
+
+    use execution_utils::unified_circuit::compute_unified_setup_for_machine_configuration;
+    use risc_verifier::prover::riscv_transpiler::cycle::IWithoutByteAccessIsaConfigWithDelegation;
+
+    let setup = compute_unified_setup_for_machine_configuration::<
+        IWithoutByteAccessIsaConfigWithDelegation,
+    >(&padded_binary, &padded_text);
+
+    BinaryCommitment {
+        end_params: setup.end_params,
+        aux_params: [0; 8],
+    }
+}
+
 #[test]
 pub(crate) fn risc_wrapper_full_test() {
-    use std::io::Read;
     let worker = boojum::worker::Worker::new_with_num_threads(32);
 
-    let binary_commitment = {
-        let mut binary = vec![];
-        let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
-        file.read_to_end(&mut binary).unwrap();
-
-        let mut text = vec![];
-        let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
-        file.read_to_end(&mut text).unwrap();
-
-        BinaryCommitment::from_base_binary(&binary, &text)
-    };
+    let binary_commitment = binary_commitment_for_testing();
     dbg!(binary_commitment);
 
     let program_proof: execution_utils::unrolled::UnrolledProgramProof =
@@ -93,14 +111,7 @@ pub(crate) fn risc_wrapper_setup_test() {
     use std::io::Read;
     let worker = boojum::worker::Worker::new();
 
-    let mut binary = vec![];
-    let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
-    file.read_to_end(&mut binary).unwrap();
-    let mut text = vec![];
-    let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
-    file.read_to_end(&mut text).unwrap();
-
-    let binary_commitment = BinaryCommitment::from_base_binary(&binary, &text);
+    let binary_commitment = binary_commitment_for_testing();
 
     let (_finalization_hint, _setup_base, _setup, vk, _setup_tree, _vars_hint, _witness_hints) =
         crate::get_risc_wrapper_setup(&worker, binary_commitment, false);
@@ -214,14 +225,7 @@ fn test_verifier_inner_function() {
     let program_proof: execution_utils::unrolled::UnrolledProgramProof =
         crate::deserialize_from_file(path).unwrap();
 
-    use std::io::Read;
-    let mut binary = vec![];
-    let mut file = std::fs::File::open(RISC_PROGRAM_BIN_PATH).unwrap();
-    file.read_to_end(&mut binary).unwrap();
-    let mut text = vec![];
-    let mut file = std::fs::File::open(RISC_PROGRAM_TEXT_PATH).unwrap();
-    file.read_to_end(&mut text).unwrap();
-    let binary_commitment = BinaryCommitment::from_base_binary(&binary, &text);
+    let binary_commitment = binary_commitment_for_testing();
 
     let risc_wrapper_witness =
         RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, false);

--- a/wrapper/src/tests/risc_wrapper_tests.rs
+++ b/wrapper/src/tests/risc_wrapper_tests.rs
@@ -16,7 +16,9 @@ use super::*;
 fn binary_commitment_for_testing() -> BinaryCommitment {
     #[cfg(feature = "security_100")]
     {
-        BinaryCommitment::default()
+        // Explicit `return` (not a tail expression) so the function still compiles
+        // if both security features are somehow enabled together.
+        return BinaryCommitment::default();
     }
     #[cfg(feature = "security_80")]
     {

--- a/wrapper/src/tests/risc_wrapper_tests.rs
+++ b/wrapper/src/tests/risc_wrapper_tests.rs
@@ -42,7 +42,7 @@ pub(crate) fn risc_wrapper_full_test() {
         deserialize_from_bin_file(RISC_PROOF_PATH).unwrap();
 
     let risc_wrapper_witness =
-        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, false);
+        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, false).unwrap();
 
     #[cfg(not(feature = "gpu"))]
     let (risc_wrapper_proof, risc_wrapper_vk) = {
@@ -228,7 +228,7 @@ fn test_verifier_inner_function() {
     let binary_commitment = binary_commitment_for_testing();
 
     let risc_wrapper_witness =
-        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, false);
+        RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment, false).unwrap();
 
     use crate::RiscWrapper;
 

--- a/wrapper/src/tests/size_estimator.rs
+++ b/wrapper/src/tests/size_estimator.rs
@@ -98,9 +98,16 @@ fn try_synthesize_wrapper_with_params(
 
         let mut owned_cs = builder.build(1 << 27);
 
-        let binary_commitment = BinaryCommitment::from_default_binary();
+        use std::io::Read;
+        let mut binary = vec![];
+        let mut file = std::fs::File::open(crate::tests::RISC_PROGRAM_BIN_PATH).unwrap();
+        file.read_to_end(&mut binary).unwrap();
+        let mut text = vec![];
+        let mut file = std::fs::File::open(crate::tests::RISC_PROGRAM_TEXT_PATH).unwrap();
+        file.read_to_end(&mut text).unwrap();
+        let binary_commitment = BinaryCommitment::from_base_binary(&binary, &text);
         use crate::RiscWrapper;
-        let circuit = RiscWrapper::new(None, false, binary_commitment);
+        let circuit = RiscWrapper::new(None, false, binary_commitment, false);
         circuit.add_tables(&mut owned_cs);
         circuit.synthesize_into_cs(&mut owned_cs);
         owned_cs.pad_and_shrink();

--- a/wrapper/src/wrapper/cpu.rs
+++ b/wrapper/src/wrapper/cpu.rs
@@ -74,10 +74,11 @@ impl BackendState {
         &mut self,
         witness: RiscWrapperWitness,
         binary_commitment: BinaryCommitment,
+        check_aux_params: bool,
         worker: &BoojumWorker,
     ) -> anyhow::Result<RiscWrapperProof> {
         let start = Instant::now();
-        let cache = self.ensure_risc_wrapper_setup(binary_commitment, worker)?;
+        let cache = self.ensure_risc_wrapper_setup(binary_commitment, check_aux_params, worker)?;
         tracing::info!(
             "Phase 1 setup ready in {:.3}s",
             start.elapsed().as_secs_f64()
@@ -95,6 +96,7 @@ impl BackendState {
             &cache.witness_hints,
             worker,
             binary_commitment,
+            check_aux_params,
         );
         tracing::info!("Phase 1 proving took {:.3}s", start.elapsed().as_secs_f64());
 
@@ -104,10 +106,11 @@ impl BackendState {
     pub(crate) fn risc_wrapper_vk(
         &mut self,
         binary_commitment: BinaryCommitment,
+        check_aux_params: bool,
         worker: &BoojumWorker,
     ) -> anyhow::Result<&RiscWrapperVK> {
         let start = Instant::now();
-        let cache = self.ensure_risc_wrapper_setup(binary_commitment, worker)?;
+        let cache = self.ensure_risc_wrapper_setup(binary_commitment, check_aux_params, worker)?;
         tracing::info!(
             "Phase 1 setup ready in {:.3}s",
             start.elapsed().as_secs_f64()
@@ -210,11 +213,12 @@ impl BackendState {
     fn ensure_risc_wrapper_setup(
         &mut self,
         binary_commitment: BinaryCommitment,
+        check_aux_params: bool,
         worker: &BoojumWorker,
     ) -> anyhow::Result<&RiscWrapperSetupCache> {
         if self.risc_wrapper.is_none() {
             let (finalization_hint, setup_base, setup, vk, setup_tree, vars_hint, witness_hints) =
-                crate::get_risc_wrapper_setup(worker, binary_commitment);
+                crate::get_risc_wrapper_setup(worker, binary_commitment, check_aux_params);
 
             self.risc_wrapper = Some(RiscWrapperSetupCache {
                 finalization_hint,

--- a/wrapper/src/wrapper/gpu.rs
+++ b/wrapper/src/wrapper/gpu.rs
@@ -70,12 +70,13 @@ impl BackendState {
         &mut self,
         witness: RiscWrapperWitness,
         binary_commitment: BinaryCommitment,
+        check_aux_params: bool,
         worker: &BoojumWorker,
     ) -> anyhow::Result<RiscWrapperProof> {
         let start = Instant::now();
         self.ensure_stark_context()
             .context("while attempting to prepare the STARK GPU context")?;
-        let cache = self.ensure_risc_wrapper_setup(binary_commitment, worker)?;
+        let cache = self.ensure_risc_wrapper_setup(binary_commitment, check_aux_params, worker)?;
         tracing::info!(
             "Phase 1 GPU setup ready in {:.3}s",
             start.elapsed().as_secs_f64()
@@ -89,6 +90,7 @@ impl BackendState {
             &cache.vk,
             worker,
             binary_commitment,
+            check_aux_params,
         );
         tracing::info!(
             "Phase 1 GPU proving took {:.3}s",
@@ -101,10 +103,11 @@ impl BackendState {
     pub(crate) fn risc_wrapper_vk(
         &mut self,
         binary_commitment: BinaryCommitment,
+        check_aux_params: bool,
         worker: &BoojumWorker,
     ) -> anyhow::Result<&RiscWrapperVK> {
         let start = Instant::now();
-        let cache = self.ensure_risc_wrapper_setup(binary_commitment, worker)?;
+        let cache = self.ensure_risc_wrapper_setup(binary_commitment, check_aux_params, worker)?;
         tracing::info!(
             "Phase 1 GPU setup ready in {:.3}s",
             start.elapsed().as_secs_f64()
@@ -222,13 +225,18 @@ impl BackendState {
     fn ensure_risc_wrapper_setup(
         &mut self,
         binary_commitment: BinaryCommitment,
+        check_aux_params: bool,
         worker: &BoojumWorker,
     ) -> anyhow::Result<&RiscWrapperSetupCache> {
         if self.risc_wrapper.is_none() {
             self.ensure_stark_context()
                 .context("while attempting to initialize the phase 1 GPU prover context")?;
             let (gpu_setup, vk, finalization_hint) =
-                crate::gpu::risc_wrapper::get_risc_wrapper_setup(worker, binary_commitment);
+                crate::gpu::risc_wrapper::get_risc_wrapper_setup(
+                    worker,
+                    binary_commitment,
+                    check_aux_params,
+                );
 
             self.risc_wrapper = Some(RiscWrapperSetupCache {
                 finalization_hint,

--- a/wrapper/src/wrapper/mod.rs
+++ b/wrapper/src/wrapper/mod.rs
@@ -34,6 +34,10 @@ pub struct SnarkWrapperConfig {
     pub text: Option<PathBuf>,
     pub trusted_setup: Option<PathBuf>,
     pub threads: Option<usize>,
+    /// When enabled, the RISC wrapper circuit packs registers 10..18 directly as
+    /// public inputs (no keccak) and constrains registers 18..26 to equal
+    /// `BinaryCommitment::aux_params` instead of folding them into the digest.
+    pub check_aux_params: bool,
     /// Trusted phase-1 VK to be reused instead of deriving it from the binary.
     pub risc_wrapper_vk: Option<RiscWrapperVK>,
     /// Trusted phase-2 VK to be reused instead of deriving it from the phase-1 VK.
@@ -81,16 +85,24 @@ impl SnarkWrapper {
         program_proof: UnrolledProgramProof,
     ) -> anyhow::Result<RiscWrapperProof> {
         let binary_commitment = self.binary_commitment()?;
+        let check_aux_params = self.config.check_aux_params;
         let start = Instant::now();
-        let witness = RiscWrapperWitness::from_full_proof(program_proof, &binary_commitment);
+        let witness = RiscWrapperWitness::from_full_proof(
+            program_proof,
+            &binary_commitment,
+            check_aux_params,
+        );
         tracing::info!(
             "Phase 1 witness generation took {:.3}s",
             start.elapsed().as_secs_f64()
         );
 
-        let proof = self
-            .backend
-            .prove_risc_wrapper(witness, binary_commitment, &self.worker)?;
+        let proof = self.backend.prove_risc_wrapper(
+            witness,
+            binary_commitment,
+            check_aux_params,
+            &self.worker,
+        )?;
         let start = Instant::now();
         if !self
             .verify_risc_wrapper(&proof)
@@ -131,9 +143,10 @@ impl SnarkWrapper {
         }
 
         let binary_commitment = self.binary_commitment()?;
+        let check_aux_params = self.config.check_aux_params;
 
         self.backend
-            .risc_wrapper_vk(binary_commitment, &self.worker)
+            .risc_wrapper_vk(binary_commitment, check_aux_params, &self.worker)
     }
 
     /// Proves phase 2 and verifies the generated compression proof before returning it.
@@ -271,7 +284,11 @@ impl SnarkWrapper {
         }
 
         let start = Instant::now();
-        let binary_commitment = load_binary_commitment(&self.config.bin, &self.config.text)?;
+        let binary_commitment = load_binary_commitment(
+            &self.config.bin,
+            &self.config.text,
+            self.config.check_aux_params,
+        )?;
         tracing::info!(
             "Binary commitment loading took {:.3}s",
             start.elapsed().as_secs_f64()
@@ -313,7 +330,14 @@ fn validate_trusted_setup_file(trusted_setup: &Option<PathBuf>) -> anyhow::Resul
 fn load_binary_commitment(
     bin: &Option<PathBuf>,
     text: &Option<PathBuf>,
+    check_aux_params: bool,
 ) -> anyhow::Result<BinaryCommitment> {
+    if !check_aux_params {
+        // `aux_params` is never consumed in this mode; `end_params` comes solely
+        // from the fixed unified verifier binary, so the base program is not needed.
+        return Ok(BinaryCommitment::default());
+    }
+
     match (bin, text) {
         (Some(bin_path), Some(text_path)) => {
             let binary = std::fs::read(bin_path).with_context(|| {
@@ -329,9 +353,13 @@ fn load_binary_commitment(
                 )
             })?;
 
-            Ok(BinaryCommitment::from_binary(&binary, &text_data))
+            Ok(BinaryCommitment::from_base_binary(&binary, &text_data))
         }
-        (None, None) => Ok(BinaryCommitment::from_default_binary()),
+        (None, None) => {
+            anyhow::bail!(
+                "--bin and --text are required when --check-aux-params is set (path to the base program)"
+            )
+        }
         _ => anyhow::bail!("Both --bin and --text must be provided together"),
     }
 }

--- a/wrapper/src/wrapper/mod.rs
+++ b/wrapper/src/wrapper/mod.rs
@@ -333,6 +333,13 @@ fn load_binary_commitment(
     check_aux_params: bool,
 ) -> anyhow::Result<BinaryCommitment> {
     if !check_aux_params {
+        if bin.is_some() || text.is_some() {
+            tracing::warn!(
+                "--bin/--text are ignored without --check-aux-params: end_params always comes \
+                 from the fixed unified verifier binary, so the resulting VK does not depend on \
+                 them. Pass --check-aux-params to bind the base program via aux_params."
+            );
+        }
         // `aux_params` is never consumed in this mode; `end_params` comes solely
         // from the fixed unified verifier binary, so the base program is not needed.
         return Ok(BinaryCommitment::default());

--- a/wrapper/src/wrapper/mod.rs
+++ b/wrapper/src/wrapper/mod.rs
@@ -91,7 +91,7 @@ impl SnarkWrapper {
             program_proof,
             &binary_commitment,
             check_aux_params,
-        );
+        )?;
         tracing::info!(
             "Phase 1 witness generation took {:.3}s",
             start.elapsed().as_secs_f64()

--- a/wrapper/src/wrapper/mod.rs
+++ b/wrapper/src/wrapper/mod.rs
@@ -34,8 +34,8 @@ pub struct SnarkWrapperConfig {
     pub text: Option<PathBuf>,
     pub trusted_setup: Option<PathBuf>,
     pub threads: Option<usize>,
-    /// When enabled, the RISC wrapper circuit packs registers 10..18 directly as
-    /// public inputs (no keccak) and constrains registers 18..26 to equal
+    /// When enabled, the RISC wrapper circuit packs registers 10..=16 directly as
+    /// public inputs (no keccak) and constrains registers 18..=25 to equal
     /// `BinaryCommitment::aux_params` instead of folding them into the digest.
     pub check_aux_params: bool,
     /// Trusted phase-1 VK to be reused instead of deriving it from the binary.


### PR DESCRIPTION
## What ❔

New mode for wrapper: check aux_params (binary chain commitment) inside the wrapper instead of passing it to L1.
Turns on with --check-aux-params flag
Separate cli command: compute-aux-params. Computes aux_params from base program binaries.

## Why ❔

The new mode is less flexible, but easier to integrate